### PR TITLE
Categorical integers bug discovered and squished

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.9
 
 RUN apt-get update
 

--- a/csvqb/csvqb/tests/unit/utils/qb/test_standardise.py
+++ b/csvqb/csvqb/tests/unit/utils/qb/test_standardise.py
@@ -167,5 +167,46 @@ def test_convert_data_values_to_uri_safe_values_missing_value_mapping():
     )
 
 
+def test_qbcube_catagorical_numberic():
+    """
+    Ensure that when we convert a QbCube's dataframe columns to categorical, and it works for numeric
+    """
+    data = pd.DataFrame(
+        {"Some Dimension": [2014, 2015, 2016], "Observed Value": [1, 2, 3]}
+    )
+    cube = Cube(
+        CatalogMetadata("Some Qube"),
+        data,
+        [
+            QbColumn(
+                "Some Dimension",
+                NewQbDimension.from_data("Some Dimension", data["Some Dimension"]),
+            ),
+            QbColumn(
+                "Observed Value",
+                QbSingleMeasureObservationValue(
+                    NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
+                ),
+            ),
+        ],
+    )
+
+    ensure_qbcube_data_is_categorical(cube)
+
+    map_col_to_expected_categories = {
+        "Some Dimension": {2014, 2015, 2016},
+    }
+    expected_non_categorical_columns = {"Observed Value"}
+
+    for (column_name, expected_categories) in map_col_to_expected_categories.items():
+        values = cube.data[column_name].values
+        assert isinstance(values, Categorical)
+        assert set(values.categories) == expected_categories
+
+    for column_name in expected_non_categorical_columns:
+        values = cube.data[column_name].values
+        assert not isinstance(values, Categorical)
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/csvqb/csvqb/utils/qb/standardise.py
+++ b/csvqb/csvqb/utils/qb/standardise.py
@@ -140,7 +140,7 @@ def _overwrite_labels_for_columns(
         assert isinstance(column_values, Categorical)
         new_category_labels: List[str] = []
         for c in column_values.categories:
-            assert isinstance(c, str)
+            c = str(c)
             new_category_label = map_unit_label_to_new_value.get(c)
             if new_category_label is None:
                 if raise_missing_values_exceptions:


### PR DESCRIPTION
We've got two things in this PR.

* We now support categorical numerics
* Fixed python to 3.9 since python:latest is now 3.10 and there are issues yet to be discovered #195 