### PR TITLE
Issue #105 - PMDise Catalog Metadata

### DIFF
--- a/csvcubed-devtools/csvcubeddevtools/behaviour/rdf.py
+++ b/csvcubed-devtools/csvcubeddevtools/behaviour/rdf.py
@@ -5,8 +5,9 @@ RDF Test Steps
 from pathlib import Path
 from behave import *
 from rdflib.compare import to_isomorphic, graph_diff
-from rdflib import Graph
+from rdflib import Graph, Dataset, ConjunctiveGraph
 import distutils.util
+from .temporarydirectory import get_context_temp_dir_path
 
 
 def test_graph_diff(g1, g2):
@@ -45,6 +46,16 @@ def assert_ask(context, ask_query: str, expected_ask_result: bool):
     results = list(g.query(ask_query))
     ask_result = results[0]
     assert ask_result == expected_ask_result
+
+
+@given('the RDF contained in "{rdf_file}"')
+def step_impl(context, rdf_file: str):
+    rdf_file_path = get_context_temp_dir_path(context) / rdf_file
+    graph = ConjunctiveGraph()
+    graph.parse(str(rdf_file_path), format="nquads")
+    context.turtle = getattr(context, "turtle", "") + graph.serialize(
+        format="turtle"
+    ).decode("utf-8")
 
 
 @step('the RDF should not contain any instances of "{entity_type}"')

--- a/csvcubed-devtools/csvcubeddevtools/behaviour/rdf.py
+++ b/csvcubed-devtools/csvcubeddevtools/behaviour/rdf.py
@@ -2,10 +2,9 @@
 RDF Test Steps
 --------------
 """
-from pathlib import Path
 from behave import *
 from rdflib.compare import to_isomorphic, graph_diff
-from rdflib import Graph, Dataset, ConjunctiveGraph
+from rdflib import Graph, ConjunctiveGraph
 import distutils.util
 from .temporarydirectory import get_context_temp_dir_path
 
@@ -48,7 +47,7 @@ def assert_ask(context, ask_query: str, expected_ask_result: bool):
     assert ask_result == expected_ask_result
 
 
-@given('the RDF contained in "{rdf_file}"')
+@given('the N-Quads contained in "{rdf_file}"')
 def step_impl(context, rdf_file: str):
     rdf_file_path = get_context_temp_dir_path(context) / rdf_file
     graph = ConjunctiveGraph()

--- a/csvcubed-pmd/csvcubedpmd/csvwcli/__init__.py
+++ b/csvcubed-pmd/csvcubedpmd/csvwcli/__init__.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Any
 import click
 
 import csvcubedpmd.csvwcli.pull as pull

--- a/csvcubed-pmd/csvcubedpmd/dcatcli/__init__.py
+++ b/csvcubed-pmd/csvcubedpmd/dcatcli/__init__.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import click
+
+from .pmdify import pmdify_dcat
+
+
+@click.group("dcat")
+def dcat_group():
+    """
+    Work with CSV-Ws.
+    """
+    pass
+
+
+@dcat_group.command("pmdify")
+@click.argument(
+    "csvw_metadata_file",
+    type=click.Path(exists=True, path_type=Path, file_okay=True, dir_okay=False),
+    metavar="CSVW_METADATA_FILE",
+)
+def _pmdify(csvw_metadata_file: Path) -> None:
+    """
+    Given a local CSV-W metadata file, re-work the DCATv2 metadata such that it ends up in the format required for PMD
+    """
+    pmdify_dcat(csvw_metadata_file)

--- a/csvcubed-pmd/csvcubedpmd/dcatcli/__init__.py
+++ b/csvcubed-pmd/csvcubedpmd/dcatcli/__init__.py
@@ -7,7 +7,7 @@ from .pmdify import pmdify_dcat
 @click.group("dcat")
 def dcat_group():
     """
-    Work with CSV-Ws.
+    Work with DCAT metadata.
     """
     pass
 

--- a/csvcubed-pmd/csvcubedpmd/dcatcli/__init__.py
+++ b/csvcubed-pmd/csvcubedpmd/dcatcli/__init__.py
@@ -18,8 +18,30 @@ def dcat_group():
     type=click.Path(exists=True, path_type=Path, file_okay=True, dir_okay=False),
     metavar="CSVW_METADATA_FILE",
 )
-def _pmdify(csvw_metadata_file: Path) -> None:
+@click.argument(
+    "base_uri",
+    type=str,
+    metavar="BASE_URI",
+)
+@click.argument(
+    "data_graph_uri",
+    type=str,
+    metavar="DATA_GRAPH_URI",
+)
+@click.argument(
+    "catalog_metadata_graph_uri",
+    type=str,
+    metavar="CATALOG_METADATA_GRAPH_URI",
+)
+def _pmdify(
+    csvw_metadata_file: Path,
+    base_uri: str,
+    data_graph_uri: str,
+    catalog_metadata_graph_uri: str,
+) -> None:
     """
     Given a local CSV-W metadata file, re-work the DCATv2 metadata such that it ends up in the format required for PMD
     """
-    pmdify_dcat(csvw_metadata_file)
+    pmdify_dcat(
+        csvw_metadata_file, base_uri, data_graph_uri, catalog_metadata_graph_uri
+    )

--- a/csvcubed-pmd/csvcubedpmd/dcatcli/__init__.py
+++ b/csvcubed-pmd/csvcubedpmd/dcatcli/__init__.py
@@ -40,7 +40,9 @@ def _pmdify(
     catalog_metadata_graph_uri: str,
 ) -> None:
     """
-    Given a local CSV-W metadata file, re-work the DCATv2 metadata such that it ends up in the format required for PMD
+    Given a local CSV-W metadata file, re-work the DCATv2 metadata such that it ends up in the format required for PMD.
+
+    Outputs an N-Quads file containing PMDCAT metadata at <CSVW_METADATA_FILE>.nq
     """
     pmdify_dcat(
         csvw_metadata_file, base_uri, data_graph_uri, catalog_metadata_graph_uri

--- a/csvcubed-pmd/csvcubedpmd/dcatcli/__init__.py
+++ b/csvcubed-pmd/csvcubedpmd/dcatcli/__init__.py
@@ -40,9 +40,11 @@ def _pmdify(
     catalog_metadata_graph_uri: str,
 ) -> None:
     """
-    Given a local CSV-W metadata file, re-work the DCATv2 metadata such that it ends up in the format required for PMD.
+    Given a local CSV-W metadata.json file, re-work the DCATv2 metadata such that it ends up in the format required
+    for PMD.
 
-    Outputs an N-Quads file containing PMDCAT metadata at <CSVW_METADATA_FILE>.nq
+    Removes the expected DCAT metadata from the CSV-W metadata.json file and outputs a new N-Quads file containing
+    PMDCAT metadata at <CSVW_METADATA_FILE>.nq
     """
     pmdify_dcat(
         csvw_metadata_file, base_uri, data_graph_uri, catalog_metadata_graph_uri

--- a/csvcubed-pmd/csvcubedpmd/dcatcli/pmdify.py
+++ b/csvcubed-pmd/csvcubedpmd/dcatcli/pmdify.py
@@ -1,0 +1,289 @@
+"""
+PMDify DCAT Metadata
+--------------------
+
+Functionality to convert a CSV-W's DCATv2 metadata into the structure necessary for PMD.
+"""
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Any, Callable
+
+import dateutil
+import rdflib
+from csvcubedmodels.rdf import ExistingResource
+from rdflib import Graph, Literal, URIRef
+
+from csvcubedpmd.config import pmdconfig
+from csvcubedpmd.models.CsvCubedOutputType import CsvCubedOutputType
+from csvcubedpmd.models.rdf import pmdcat
+
+
+def pmdify_dcat(
+    csvw_metadata_file_path: Path,
+    data_graph_uri: str,
+    catalog_metadata_graph_uri: str,
+) -> None:
+    """
+    Modifies `csvw_metadata_file_path` which is a standard csvcubed output to remove the `dcat` dataset metadata.
+
+    Adds a new file located at `csvw_metadata_file_path`.nq containing the catalogue metadata in quad form.
+    """
+
+    csvw_rdf_graph = Graph()
+    with open(csvw_metadata_file_path, "r") as f:
+        csvw_file_contents_json = json.load(f)
+
+    rdf_metadata = csvw_file_contents_json["rdfs:seeAlso"]
+    csvw_rdf_graph.parse(rdf_metadata, format="json-ld")
+
+    csvw_type = _get_csv_cubed_output_type(csvw_rdf_graph)
+
+    catalog_entry = _get_catalog_entry_from_dcat_dataset(csvw_rdf_graph)
+    catalog_record = _generate_pmd_catalog_record(
+        catalog_entry, data_graph_uri, catalog_metadata_graph_uri, csvw_type
+    )
+
+    _delete_existing_dcat_dataset_metadata(csvw_rdf_graph)
+
+    csvw_file_contents_json["rdfs:seeAlso"] = json.loads(
+        csvw_rdf_graph.serialize(format="json-ld") or "[]"
+    )
+
+    # Write removal of dcat metadata from CSV-W to disk.
+    with open(csvw_metadata_file_path, "w") as f:
+        json.dump(f, csvw_file_contents_json, indent=4)
+
+    # Write separate N-Quads file containing pmdified catalogue metadata.
+    catalog_metadata_quads_file_path = Path(f"{csvw_metadata_file_path.absolute()}.nq")
+    _write_catalog_metadata_to_quads(
+        catalog_record, catalog_metadata_quads_file_path, catalog_metadata_graph_uri
+    )
+
+
+def _generate_pmd_catalog_record(
+    catalog_entry: pmdcat.Dataset,
+    data_graph_uri: str,
+    catalog_metadata_graph_uri: str,
+    csv_cubed_output_type: CsvCubedOutputType,
+) -> pmdcat.CatalogRecord:
+    catalog_entry.dataset_contents = ExistingResource(catalog_entry.uri)
+
+    # N.B. assumes that all URIs are hash URIs, this may not always be the case.
+    catalog_entry_uri = catalog_entry.uri.replace("#.*?$", "#catalog-entry")
+    catalog_record_uri = catalog_entry.uri.replace("#.*?$", "#catalog-record")
+    catalog_entry.uri = URIRef(catalog_entry_uri)
+
+    # Catalog -(dcat:record)-> Catalog Record -(foaf:primaryTopic)-> Dataset -(pmdcat:datasetContents)->
+    # qb:DataSet/skos:ConceptScheme
+
+    catalog_uri = _get_catalog_uri_to_add_to(csv_cubed_output_type)
+
+    catalog_record = pmdcat.CatalogRecord(catalog_record_uri, catalog_uri)
+    catalog_record.title = catalog_entry.title
+    catalog_record.label = catalog_entry.label
+    catalog_record.description = catalog_entry.description
+    catalog_record.comment = catalog_entry.comment
+    catalog_record.issued = catalog_record.modified = datetime.now()
+    catalog_record.metadata_graph = catalog_metadata_graph_uri
+    catalog_record.primary_topic = catalog_entry
+    catalog_entry.metadata_graph = catalog_metadata_graph_uri
+
+    catalog_entry.pmdcat_graph = data_graph_uri
+    catalog_entry.sparql_endpoint = pmdconfig.SPARQL_ENDPOINT
+
+    return catalog_record
+
+
+def _get_catalog_uri_to_add_to(csv_cubed_output_type: CsvCubedOutputType) -> str:
+    if csv_cubed_output_type == CsvCubedOutputType.SkosConceptScheme:
+        return pmdconfig.CODE_LIST_CATALOG_URI
+    elif csv_cubed_output_type == CsvCubedOutputType.QbDataSet:
+        return pmdconfig.DATASET_CATALOG_URI
+    else:
+        raise Exception(
+            f"Unmatched {CsvCubedOutputType.__name__} '{csv_cubed_output_type}'"
+        )
+
+
+def _write_catalog_metadata_to_quads(
+    catalog_record: pmdcat.Dataset,
+    catalog_metadata_quads_file_path: Path,
+    catalog_metadata_graph_uri: str,
+) -> None:
+    catalog_metadata_ds = rdflib.Dataset()
+    catalog_metadata_graph = catalog_record.to_graph(
+        catalog_metadata_ds.graph(catalog_metadata_graph_uri)
+    )
+    catalog_record.to_graph(catalog_metadata_graph)
+    catalog_metadata_graph.serialize(catalog_metadata_quads_file_path, format="nq")
+
+
+def _delete_existing_dcat_dataset_metadata(csvw_graph: Graph) -> None:
+    """
+    Removes the existing `dcat:Dataset` and associated metadata from the :obj:`csvw_graph` passed in.
+    """
+    csvw_graph.update(
+        """
+        PREFIX dcat: <http://www.w3.org/ns/dcat#>
+        PREFIX dcterms: <http://purl.org/dc/terms/>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        DELETE {
+            ?dataset a dcat:Dataset;
+                dcterms:issued ?issued;
+                dcterms:modified ?modified;
+                rdfs:comment ?comment;
+                dcterms:description ?description;
+                dcterms:license ?license;
+                dcterms:creator ?creator;
+                dcterms:publisher ?publisher;
+                dcat:landingPage ?landingPage;
+                dcat:theme ?theme;
+                dcat:keyword ?keyword;
+                dcat:contactPoint ?contactPoint;
+                dcterms:identifier ?identifier.
+        }
+        WHERE {
+            ?dataset a dcat:Dataset;
+                dcterms:issued ?issued;
+                dcterms:modified ?modified.
+
+            OPTIONAL { ?dataset rdfs:comment ?comment }.
+            OPTIONAL { ?dataset dcterms:description ?description }.
+            OPTIONAL { ?dataset dcterms:license ?license }.
+            OPTIONAL { ?dataset dcterms:creator ?creator }.
+            OPTIONAL { ?dataset dcterms:publisher ?publisher }.
+            OPTIONAL { ?dataset dcat:landingPage ?landingPage }.
+            OPTIONAL { ?dataset dcat:theme ?theme }.
+            OPTIONAL { ?dataset dcat:keyword ?keyword }.
+            OPTIONAL { ?dataset dcat:contactPoint ?contactPoint }
+            OPTIONAL { ?dataset dcterms:identifier ?identifier }                
+        }
+        """
+    )
+
+
+def _get_catalog_entry_from_dcat_dataset(csvw_graph: Graph) -> pmdcat.Dataset:
+    """
+    :return: a :class:`csvcubedpmd.models.rdf.pmdcat.Dataset` to avoid need to convert from dcat to pmdcat object.
+    """
+    results = list(
+        csvw_graph.query(
+            """
+        PREFIX dcat: <http://www.w3.org/ns/dcat#>
+        PREFIX dcterms: <http://purl.org/dc/terms/>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    
+        SELECT ?dataset ?title ?label ?issued ?modified ?comment ?description ?license ?creator ?publisher ?landingPage 
+            (GROUP_CONCAT(?theme; separator='|') as ?themes) 
+            (GROUP_CONCAT(?keyword; separator='|') as ?keywords) 
+            ?contactPoint ?identifier
+        WHERE {
+            ?dataset a dcat:Dataset;
+                dcterms:title ?title;
+                rdfs:label ?label;
+                dcterms:issued ?issued;
+                dcterms:modified ?modified.
+
+            OPTIONAL { ?dataset rdfs:comment ?comment }.
+            OPTIONAL { ?dataset dcterms:description ?description }.
+            OPTIONAL { ?dataset dcterms:license ?license }.
+            OPTIONAL { ?dataset dcterms:creator ?creator }.
+            OPTIONAL { ?dataset dcterms:publisher ?publisher }.
+            OPTIONAL { ?dataset dcat:landingPage ?landingPage }.
+            OPTIONAL { ?dataset dcat:theme ?theme }.
+            OPTIONAL { ?dataset dcat:keyword ?keyword }.
+            OPTIONAL { ?dataset dcat:contactPoint ?contactPoint }
+            OPTIONAL { ?dataset dcterms:identifier ?identifier }                
+        }
+        """
+        )
+    )
+
+    results = [
+        r
+        for r in results
+        if any([r[k] is not None and r[k] != Literal("") for k in r.labels.keys()])
+    ]
+
+    if len(results) != 1:
+        raise Exception(f"Expected 1 dcat:Dataset record, found {len(results)}")
+
+    record = results[0]
+
+    pmdcat_dataset = pmdcat.Dataset(record["dataset"])
+    pmdcat_dataset.title = _none_or_map(record["title"], str)
+    pmdcat_dataset.label = _none_or_map(record["label"], str)
+    pmdcat_dataset.issued = dateutil.parser.isoparse(record["issued"])
+    pmdcat_dataset.modified = dateutil.parser.isoparse(record["modified"])
+    pmdcat_dataset.comment = _none_or_map(record["comment"], str)
+    pmdcat_dataset.description = _none_or_map(record["description"], str)
+    pmdcat_dataset.license = _none_or_map(record["license"], str)
+    pmdcat_dataset.creator = _none_or_map(record["creator"], str)
+    pmdcat_dataset.publisher = _none_or_map(record["publisher"], str)
+    pmdcat_dataset.landing_page = _none_or_map(record["landingPage"], str)
+    pmdcat_dataset.themes = (
+        set() if len(record["themes"]) == 0 else set(str(record["themes"]).split("|"))
+    )
+    pmdcat_dataset.keywords = (
+        set()
+        if len(record["keywords"]) == 0
+        else set(str(record["keywords"]).split("|"))
+    )
+    pmdcat_dataset.contact_point = _none_or_map(record["contactPoint"], str)
+    pmdcat_dataset.identifier = _none_or_map(record["identifier"], str)
+
+    return pmdcat_dataset
+
+
+def _none_or_map(val: Optional[Any], map_func: Callable[[Any], Any]) -> Optional[Any]:
+    if val is None:
+        return None
+    else:
+        return map_func(val)
+
+
+def _get_csv_cubed_output_type(csvw_rdf_graph: Graph) -> CsvCubedOutputType:
+    is_concept_scheme = _ask_query(
+        """
+        ASK 
+        WHERE {
+            ?conceptScheme a <http://www.w3.org/2004/02/skos/core#ConceptScheme>.
+        }
+    """,
+        csvw_rdf_graph,
+    )
+
+    if is_concept_scheme:
+        return CsvCubedOutputType.SkosConceptScheme
+
+    is_qb_dataset = _ask_query(
+        """
+        ASK 
+        WHERE {
+            ?qbDataSet a <http://purl.org/linked-data/cube#DataSet>.
+        }
+    """,
+        csvw_rdf_graph,
+    )
+
+    if is_qb_dataset:
+        return CsvCubedOutputType.QbDataSet
+
+    raise Exception(
+        f"Could not determine {CsvCubedOutputType.__name__} for input CSV-W graph."
+    )
+
+
+def _ask_query(query: str, graph: Graph) -> bool:
+    results = list(graph.query(query))
+
+    if len(results) == 1:
+        result = results[0]
+        if isinstance(result, bool):
+            return result
+        else:
+            raise Exception(f"Unexpected ASK query response type {type(result)}")
+    else:
+        raise Exception(f"Unexpected number of results for ASK query {len(results)}.")

--- a/csvcubed-pmd/csvcubedpmd/dcatcli/pmdify.py
+++ b/csvcubed-pmd/csvcubedpmd/dcatcli/pmdify.py
@@ -58,7 +58,7 @@ def pmdify_dcat(
 
     _replace_uri_substring_in_graph(csvw_rdf_graph, str(_TEMP_PREFIX_URI), base_uri)
     csvw_file_contents_json["rdfs:seeAlso"] = json.loads(
-        csvw_rdf_graph.serialize(format="json-ld").decode("UTF-8")
+        csvw_rdf_graph.serialize(format="json-ld").decode("UTF-8")  # type: ignore
     )
 
     initial_id = csvw_file_contents_json.get("@id", "")
@@ -155,15 +155,18 @@ def _get_catalog_uri_to_add_to(csv_cubed_output_type: CsvCubedOutputType) -> str
 
 
 def _write_catalog_metadata_to_quads(
-    catalog_record: pmdcat.Dataset,
+    catalog_record: pmdcat.CatalogRecord,
     catalog_metadata_quads_file_path: Path,
     catalog_metadata_graph_uri: str,
     base_uri: str,
 ) -> None:
     catalog_metadata_ds = rdflib.Dataset()
-    catalog_metadata_graph = catalog_record.to_graph(
-        catalog_metadata_ds.graph(catalog_metadata_graph_uri, base=_TEMP_PREFIX_URI)
+    catalog_metadata_graph = catalog_metadata_ds.graph(
+        catalog_metadata_graph_uri, base=_TEMP_PREFIX_URI
     )
+    assert catalog_metadata_graph is not None
+
+    catalog_metadata_graph = catalog_record.to_graph(catalog_metadata_graph)
     catalog_record.to_graph(catalog_metadata_graph)
     _replace_uri_substring_in_graph(
         catalog_metadata_graph, str(_TEMP_PREFIX_URI), base_uri
@@ -269,8 +272,8 @@ def _get_catalog_entry_from_dcat_dataset(csvw_graph: Graph) -> pmdcat.Dataset:
     record = results[0]
 
     pmdcat_dataset = pmdcat.Dataset(record["dataset"])
-    pmdcat_dataset.title = _none_or_map(record["title"], str)
-    pmdcat_dataset.label = _none_or_map(record["label"], str)
+    pmdcat_dataset.title = str(record["title"])
+    pmdcat_dataset.label = str(record["label"])
     pmdcat_dataset.issued = dateutil.parser.isoparse(record["issued"])
     pmdcat_dataset.modified = dateutil.parser.isoparse(record["modified"])
     pmdcat_dataset.comment = _none_or_map(record["comment"], str)

--- a/csvcubed-pmd/csvcubedpmd/dcatcli/pmdify.py
+++ b/csvcubed-pmd/csvcubedpmd/dcatcli/pmdify.py
@@ -291,7 +291,7 @@ def _get_catalog_entry_from_dcat_dataset(csvw_graph: Graph) -> pmdcat.Dataset:
         else set(str(record["keywords"]).split("|"))
     )
     pmdcat_dataset.contact_point = _none_or_map(record["contactPoint"], str)
-    pmdcat_dataset.identifier = _none_or_map(record["identifier"], str)
+    pmdcat_dataset.identifier = str(record["identifier"])
 
     return pmdcat_dataset
 

--- a/csvcubed-pmd/csvcubedpmd/main.py
+++ b/csvcubed-pmd/csvcubedpmd/main.py
@@ -4,11 +4,10 @@ PMD Tools CLI
 """
 import click
 
-
-from csvcubedpmd import csvwcli
+from csvcubedpmd import csvwcli, dcatcli
 
 entry_point = click.Group(
-    commands=[csvwcli.csvw_group],
+    commands=[csvwcli.csvw_group, dcatcli.dcat_group],
     help="pmdutils - Utils for helping convert CSV-Ws to PMD-compatible RDF.",
     context_settings=dict(help_option_names=["-h", "--help"]),
 )

--- a/csvcubed-pmd/csvcubedpmd/models/CsvCubedOutputType.py
+++ b/csvcubed-pmd/csvcubedpmd/models/CsvCubedOutputType.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class CsvCubedOutputType(Enum):
+    QbDataSet = 1
+    SkosConceptScheme = 2

--- a/csvcubed-pmd/poetry.lock
+++ b/csvcubed-pmd/poetry.lock
@@ -267,7 +267,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "imagesize"
-version = "1.2.0"
+version = "1.3.0"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
 category = "dev"
 optional = false
@@ -294,7 +294,7 @@ six = "*"
 
 [[package]]
 name = "jinja2"
-version = "3.0.2"
+version = "3.0.3"
 description = "A very fast and expressive template engine."
 category = "dev"
 optional = false
@@ -634,7 +634,7 @@ rdflib = ">=5.0.0"
 
 [[package]]
 name = "regex"
-version = "2021.11.2"
+version = "2021.11.10"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -715,7 +715,7 @@ python-versions = "*"
 
 [[package]]
 name = "soupsieve"
-version = "2.3"
+version = "2.3.1"
 description = "A modern CSS selector implementation for Beautiful Soup."
 category = "dev"
 optional = false
@@ -871,11 +871,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "typed-ast"
-version = "1.4.3"
+version = "1.5.0"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "unidecode"
@@ -1025,8 +1025,8 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 imagesize = [
-    {file = "imagesize-1.2.0-py2.py3-none-any.whl", hash = "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1"},
-    {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
+    {file = "imagesize-1.3.0-py2.py3-none-any.whl", hash = "sha256:1db2f82529e53c3e929e8926a1fa9235aa82d0bd0c580359c67ec31b2fddaa8c"},
+    {file = "imagesize-1.3.0.tar.gz", hash = "sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -1037,8 +1037,8 @@ isodate = [
     {file = "isodate-0.6.0.tar.gz", hash = "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8"},
 ]
 jinja2 = [
-    {file = "Jinja2-3.0.2-py3-none-any.whl", hash = "sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c"},
-    {file = "Jinja2-3.0.2.tar.gz", hash = "sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45"},
+    {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
+    {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
@@ -1311,55 +1311,55 @@ rdflib-jsonld = [
     {file = "rdflib_jsonld-0.6.1-py2.py3-none-any.whl", hash = "sha256:bcf84317e947a661bae0a3f2aee1eced697075fc4ac4db6065a3340ea0f10fc2"},
 ]
 regex = [
-    {file = "regex-2021.11.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:897c539f0f3b2c3a715be651322bef2167de1cdc276b3f370ae81a3bda62df71"},
-    {file = "regex-2021.11.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:886f459db10c0f9d17c87d6594e77be915f18d343ee138e68d259eb385f044a8"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:075b0fdbaea81afcac5a39a0d1bb91de887dd0d93bf692a5dd69c430e7fc58cb"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c6238d30dcff141de076344cf7f52468de61729c2f70d776fce12f55fe8df790"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7fab29411d75c2eb48070020a40f80255936d7c31357b086e5931c107d48306e"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0148988af0182a0a4e5020e7c168014f2c55a16d11179610f7883dd48ac0ebe"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:be30cd315db0168063a1755fa20a31119da91afa51da2907553493516e165640"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e9cec3a62d146e8e122d159ab93ac32c988e2ec0dcb1e18e9e53ff2da4fbd30c"},
-    {file = "regex-2021.11.2-cp310-cp310-win32.whl", hash = "sha256:41c66bd6750237a8ed23028a6c9173dc0c92dc24c473e771d3bfb9ee817700c3"},
-    {file = "regex-2021.11.2-cp310-cp310-win_amd64.whl", hash = "sha256:0075fe4e2c2720a685fef0f863edd67740ff78c342cf20b2a79bc19388edf5db"},
-    {file = "regex-2021.11.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0ed3465acf8c7c10aa2e0f3d9671da410ead63b38a77283ef464cbb64275df58"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab1fea8832976ad0bebb11f652b692c328043057d35e9ebc78ab0a7a30cf9a70"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cb1e44d860345ab5d4f533b6c37565a22f403277f44c4d2d5e06c325da959883"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9486ebda015913909bc28763c6b92fcc3b5e5a67dee4674bceed112109f5dfb8"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20605bfad484e1341b2cbfea0708e4b211d233716604846baa54b94821f487cb"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f20f9f430c33597887ba9bd76635476928e76cad2981643ca8be277b8e97aa96"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1d85ca137756d62c8138c971453cafe64741adad1f6a7e63a22a5a8abdbd19fa"},
-    {file = "regex-2021.11.2-cp36-cp36m-win32.whl", hash = "sha256:af23b9ca9a874ef0ec20e44467b8edd556c37b0f46f93abfa93752ea7c0e8d1e"},
-    {file = "regex-2021.11.2-cp36-cp36m-win_amd64.whl", hash = "sha256:070336382ca92c16c45b4066c4ba9fa83fb0bd13d5553a82e07d344df8d58a84"},
-    {file = "regex-2021.11.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ef4e53e2fdc997d91f5b682f81f7dc9661db9a437acce28745d765d251902d85"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35ed5714467fc606551db26f80ee5d6aa1f01185586a7bccd96f179c4b974a11"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ee36d5113b6506b97f45f2e8447cb9af146e60e3f527d93013d19f6d0405f3b"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fba661a4966adbd2c3c08d3caad6822ecb6878f5456588e2475ae23a6e47929"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77f9d16f7970791f17ecce7e7f101548314ed1ee2583d4268601f30af3170856"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f6a28e87ba69f3a4f30d775b179aac55be1ce59f55799328a0d9b6df8f16b39d"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9267e4fba27e6dd1008c4f2983cc548c98b4be4444e3e342db11296c0f45512f"},
-    {file = "regex-2021.11.2-cp37-cp37m-win32.whl", hash = "sha256:d4bfe3bc3976ccaeb4ae32f51e631964e2f0e85b2b752721b7a02de5ce3b7f27"},
-    {file = "regex-2021.11.2-cp37-cp37m-win_amd64.whl", hash = "sha256:2bb7cae741de1aa03e3dd3a7d98c304871eb155921ca1f0d7cc11f5aade913fd"},
-    {file = "regex-2021.11.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:23f93e74409c210de4de270d4bf88fb8ab736a7400f74210df63a93728cf70d6"},
-    {file = "regex-2021.11.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:d8ee91e1c295beb5c132ebd78616814de26fedba6aa8687ea460c7f5eb289b72"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e3ff69ab203b54ce5c480c3ccbe959394ea5beef6bd5ad1785457df7acea92e"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e3c00cb5c71da655e1e5161481455479b613d500dd1bd252aa01df4f037c641f"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4abf35e16f4b639daaf05a2602c1b1d47370e01babf9821306aa138924e3fe92"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb11c982a849dc22782210b01d0c1b98eb3696ce655d58a54180774e4880ac66"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07e3755e0f070bc31567dfe447a02011bfa8444239b3e9e5cca6773a22133839"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0621c90f28d17260b41838b22c81a79ff436141b322960eb49c7b3f91d1cbab6"},
-    {file = "regex-2021.11.2-cp38-cp38-win32.whl", hash = "sha256:8fbe1768feafd3d0156556677b8ff234c7bf94a8110e906b2d73506f577a3269"},
-    {file = "regex-2021.11.2-cp38-cp38-win_amd64.whl", hash = "sha256:f9ee98d658a146cb6507be720a0ce1b44f2abef8fb43c2859791d91aace17cd5"},
-    {file = "regex-2021.11.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b3794cea825f101fe0df9af8a00f9fad8e119c91e39a28636b95ee2b45b6c2e5"},
-    {file = "regex-2021.11.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3576e173e7b4f88f683b4de7db0c2af1b209bb48b2bf1c827a6f3564fad59a97"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48b4f4810117a9072a5aa70f7fea5f86fa9efbe9a798312e0a05044bd707cc33"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5930d334c2f607711d54761956aedf8137f83f1b764b9640be21d25a976f3a4"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:956187ff49db7014ceb31e88fcacf4cf63371e6e44d209cf8816cd4a2d61e11a"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17e095f7f96a4b9f24b93c2c915f31a5201a6316618d919b0593afb070a5270e"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a56735c35a3704603d9d7b243ee06139f0837bcac2171d9ba1d638ce1df0742a"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:adf35d88d9cffc202e6046e4c32e1e11a1d0238b2fcf095c94f109e510ececea"},
-    {file = "regex-2021.11.2-cp39-cp39-win32.whl", hash = "sha256:30fe317332de0e50195665bc61a27d46e903d682f94042c36b3f88cb84bd7958"},
-    {file = "regex-2021.11.2-cp39-cp39-win_amd64.whl", hash = "sha256:85289c25f658e3260b00178757c87f033f3d4b3e40aa4abdd4dc875ff11a94fb"},
-    {file = "regex-2021.11.2.tar.gz", hash = "sha256:5e85dcfc5d0f374955015ae12c08365b565c6f1eaf36dd182476a4d8e5a1cdb7"},
+    {file = "regex-2021.11.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9345b6f7ee578bad8e475129ed40123d265464c4cfead6c261fd60fc9de00bcf"},
+    {file = "regex-2021.11.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:416c5f1a188c91e3eb41e9c8787288e707f7d2ebe66e0a6563af280d9b68478f"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0538c43565ee6e703d3a7c3bdfe4037a5209250e8502c98f20fea6f5fdf2965"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ee1227cf08b6716c85504aebc49ac827eb88fcc6e51564f010f11a406c0a667"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6650f16365f1924d6014d2ea770bde8555b4a39dc9576abb95e3cd1ff0263b36"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30ab804ea73972049b7a2a5c62d97687d69b5a60a67adca07eb73a0ddbc9e29f"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:68a067c11463de2a37157930d8b153005085e42bcb7ad9ca562d77ba7d1404e0"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:162abfd74e88001d20cb73ceaffbfe601469923e875caf9118333b1a4aaafdc4"},
+    {file = "regex-2021.11.10-cp310-cp310-win32.whl", hash = "sha256:98ba568e8ae26beb726aeea2273053c717641933836568c2a0278a84987b2a1a"},
+    {file = "regex-2021.11.10-cp310-cp310-win_amd64.whl", hash = "sha256:780b48456a0f0ba4d390e8b5f7c661fdd218934388cde1a974010a965e200e12"},
+    {file = "regex-2021.11.10-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:dba70f30fd81f8ce6d32ddeef37d91c8948e5d5a4c63242d16a2b2df8143aafc"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1f54b9b4b6c53369f40028d2dd07a8c374583417ee6ec0ea304e710a20f80a0"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fbb9dc00e39f3e6c0ef48edee202f9520dafb233e8b51b06b8428cfcb92abd30"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:666abff54e474d28ff42756d94544cdfd42e2ee97065857413b72e8a2d6a6345"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5537f71b6d646f7f5f340562ec4c77b6e1c915f8baae822ea0b7e46c1f09b733"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed2e07c6a26ed4bea91b897ee2b0835c21716d9a469a96c3e878dc5f8c55bb23"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ca5f18a75e1256ce07494e245cdb146f5a9267d3c702ebf9b65c7f8bd843431e"},
+    {file = "regex-2021.11.10-cp36-cp36m-win32.whl", hash = "sha256:93a5051fcf5fad72de73b96f07d30bc29665697fb8ecdfbc474f3452c78adcf4"},
+    {file = "regex-2021.11.10-cp36-cp36m-win_amd64.whl", hash = "sha256:b483c9d00a565633c87abd0aaf27eb5016de23fed952e054ecc19ce32f6a9e7e"},
+    {file = "regex-2021.11.10-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fff55f3ce50a3ff63ec8e2a8d3dd924f1941b250b0aac3d3d42b687eeff07a8e"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e32d2a2b02ccbef10145df9135751abea1f9f076e67a4e261b05f24b94219e36"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53db2c6be8a2710b359bfd3d3aa17ba38f8aa72a82309a12ae99d3c0c3dcd74d"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2207ae4f64ad3af399e2d30dde66f0b36ae5c3129b52885f1bffc2f05ec505c8"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5ca078bb666c4a9d1287a379fe617a6dccd18c3e8a7e6c7e1eb8974330c626a"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dd33eb9bdcfbabab3459c9ee651d94c842bc8a05fabc95edf4ee0c15a072495e"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05b7d6d7e64efe309972adab77fc2af8907bb93217ec60aa9fe12a0dad35874f"},
+    {file = "regex-2021.11.10-cp37-cp37m-win32.whl", hash = "sha256:e71255ba42567d34a13c03968736c5d39bb4a97ce98188fafb27ce981115beec"},
+    {file = "regex-2021.11.10-cp37-cp37m-win_amd64.whl", hash = "sha256:07856afef5ffcc052e7eccf3213317fbb94e4a5cd8177a2caa69c980657b3cb4"},
+    {file = "regex-2021.11.10-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ba05430e819e58544e840a68b03b28b6d328aff2e41579037e8bab7653b37d83"},
+    {file = "regex-2021.11.10-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7f301b11b9d214f83ddaf689181051e7f48905568b0c7017c04c06dfd065e244"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aaa4e0705ef2b73dd8e36eeb4c868f80f8393f5f4d855e94025ce7ad8525f50"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:788aef3549f1924d5c38263104dae7395bf020a42776d5ec5ea2b0d3d85d6646"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f8af619e3be812a2059b212064ea7a640aff0568d972cd1b9e920837469eb3cb"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85bfa6a5413be0ee6c5c4a663668a2cad2cbecdee367630d097d7823041bdeec"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f23222527b307970e383433daec128d769ff778d9b29343fb3496472dc20dabe"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:da1a90c1ddb7531b1d5ff1e171b4ee61f6345119be7351104b67ff413843fe94"},
+    {file = "regex-2021.11.10-cp38-cp38-win32.whl", hash = "sha256:0617383e2fe465732af4509e61648b77cbe3aee68b6ac8c0b6fe934db90be5cc"},
+    {file = "regex-2021.11.10-cp38-cp38-win_amd64.whl", hash = "sha256:a3feefd5e95871872673b08636f96b61ebef62971eab044f5124fb4dea39919d"},
+    {file = "regex-2021.11.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f7f325be2804246a75a4f45c72d4ce80d2443ab815063cdf70ee8fb2ca59ee1b"},
+    {file = "regex-2021.11.10-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:537ca6a3586931b16a85ac38c08cc48f10fc870a5b25e51794c74df843e9966d"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eef2afb0fd1747f33f1ee3e209bce1ed582d1896b240ccc5e2697e3275f037c7"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:432bd15d40ed835a51617521d60d0125867f7b88acf653e4ed994a1f8e4995dc"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b43c2b8a330a490daaef5a47ab114935002b13b3f9dc5da56d5322ff218eeadb"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:962b9a917dd7ceacbe5cd424556914cb0d636001e393b43dc886ba31d2a1e449"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fa8c626d6441e2d04b6ee703ef2d1e17608ad44c7cb75258c09dd42bacdfc64b"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3c5fb32cc6077abad3bbf0323067636d93307c9fa93e072771cf9a64d1c0f3ef"},
+    {file = "regex-2021.11.10-cp39-cp39-win32.whl", hash = "sha256:3b5df18db1fccd66de15aa59c41e4f853b5df7550723d26aa6cb7f40e5d9da5a"},
+    {file = "regex-2021.11.10-cp39-cp39-win_amd64.whl", hash = "sha256:83ee89483672b11f8952b158640d0c0ff02dc43d9cb1b70c1564b49abe92ce29"},
+    {file = "regex-2021.11.10.tar.gz", hash = "sha256:f341ee2df0999bfdf7a95e448075effe0db212a59387de1a70690e4acb03d4c6"},
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
@@ -1382,8 +1382,8 @@ snowballstemmer = [
     {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
 ]
 soupsieve = [
-    {file = "soupsieve-2.3-py3-none-any.whl", hash = "sha256:617ffc4d0dfd39c66f4d1413a6e165663a34eca86be9b54f97b91756300ff6df"},
-    {file = "soupsieve-2.3.tar.gz", hash = "sha256:e4860f889dfa88774c07da0b276b70c073b6470fa1a4a8350800bb7bce3dcc76"},
+    {file = "soupsieve-2.3.1-py3-none-any.whl", hash = "sha256:1a3cca2617c6b38c0343ed661b1fa5de5637f257d4fe22bd9f1338010a1efefb"},
+    {file = "soupsieve-2.3.1.tar.gz", hash = "sha256:b8d49b1cd4f037c7082a9683dfa1801aa2597fb11c3a1155b7a5b94829b4f1f9"},
 ]
 sphinx = [
     {file = "Sphinx-3.5.4-py3-none-any.whl", hash = "sha256:2320d4e994a191f4b4be27da514e46b3d6b420f2ff895d064f52415d342461e8"},
@@ -1430,36 +1430,25 @@ tomlkit = [
     {file = "tomlkit-0.7.2.tar.gz", hash = "sha256:d7a454f319a7e9bd2e249f239168729327e4dd2d27b17dc68be264ad1ce36754"},
 ]
 typed-ast = [
-    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
-    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075"},
-    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528"},
-    {file = "typed_ast-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428"},
-    {file = "typed_ast-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805"},
-    {file = "typed_ast-1.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a"},
-    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff"},
-    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41"},
-    {file = "typed_ast-1.4.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39"},
-    {file = "typed_ast-1.4.3-cp38-cp38-win32.whl", hash = "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927"},
-    {file = "typed_ast-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40"},
-    {file = "typed_ast-1.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3"},
-    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4"},
-    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0"},
-    {file = "typed_ast-1.4.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3"},
-    {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
-    {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
-    {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
+    {file = "typed_ast-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7b310a207ee9fde3f46ba327989e6cba4195bc0c8c70a158456e7b10233e6bed"},
+    {file = "typed_ast-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:52ca2b2b524d770bed7a393371a38e91943f9160a190141e0df911586066ecda"},
+    {file = "typed_ast-1.5.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:14fed8820114a389a2b7e91624db5f85f3f6682fda09fe0268a59aabd28fe5f5"},
+    {file = "typed_ast-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:65c81abbabda7d760df7304d843cc9dbe7ef5d485504ca59a46ae2d1731d2428"},
+    {file = "typed_ast-1.5.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:37ba2ab65a0028b1a4f2b61a8fe77f12d242731977d274a03d68ebb751271508"},
+    {file = "typed_ast-1.5.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:49af5b8f6f03ed1eb89ee06c1d7c2e7c8e743d720c3746a5857609a1abc94c94"},
+    {file = "typed_ast-1.5.0-cp36-cp36m-win_amd64.whl", hash = "sha256:e4374a76e61399a173137e7984a1d7e356038cf844f24fd8aea46c8029a2f712"},
+    {file = "typed_ast-1.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ea517c2bb11c5e4ba7a83a91482a2837041181d57d3ed0749a6c382a2b6b7086"},
+    {file = "typed_ast-1.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:51040bf45aacefa44fa67fb9ebcd1f2bec73182b99a532c2394eea7dabd18e24"},
+    {file = "typed_ast-1.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:806e0c7346b9b4af8c62d9a29053f484599921a4448c37fbbcbbf15c25138570"},
+    {file = "typed_ast-1.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a67fd5914603e2165e075f1b12f5a8356bfb9557e8bfb74511108cfbab0f51ed"},
+    {file = "typed_ast-1.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:224afecb8b39739f5c9562794a7c98325cb9d972712e1a98b6989a4720219541"},
+    {file = "typed_ast-1.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:155b74b078be842d2eb630dd30a280025eca0a5383c7d45853c27afee65f278f"},
+    {file = "typed_ast-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:361b9e5d27bd8e3ccb6ea6ad6c4f3c0be322a1a0f8177db6d56264fa0ae40410"},
+    {file = "typed_ast-1.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:618912cbc7e17b4aeba86ffe071698c6e2d292acbd6d1d5ec1ee724b8c4ae450"},
+    {file = "typed_ast-1.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7e6731044f748340ef68dcadb5172a4b1f40847a2983fe3983b2a66445fbc8e6"},
+    {file = "typed_ast-1.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e8a9b9c87801cecaad3b4c2b8876387115d1a14caa602c1618cedbb0cb2a14e6"},
+    {file = "typed_ast-1.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:ec184dfb5d3d11e82841dbb973e7092b75f306b625fad7b2e665b64c5d60ab3f"},
+    {file = "typed_ast-1.5.0.tar.gz", hash = "sha256:ff4ad88271aa7a55f19b6a161ed44e088c393846d954729549e3cde8257747bb"},
 ]
 unidecode = [
     {file = "Unidecode-1.3.2-py3-none-any.whl", hash = "sha256:215fe33c9d1c889fa823ccb66df91b02524eb8cc8c9c80f9c5b8129754d27829"},

--- a/csvcubed-pmd/tests/behaviour/csvwcommandline.feature
+++ b/csvcubed-pmd/tests/behaviour/csvwcommandline.feature
@@ -57,6 +57,7 @@ Feature: Testing the csvw command group in the CLI
     And the file at "out/junior-roles.csv" should exist
     And the file at "out/gov.uk/schema/junior-roles.json" should exist
 
+
     Scenario: The `pull` command should fail when the CSV-W file cannot be found.
     When the pmdutils command CLI is run with "csvw pull https://example.com/non-existant-file.csv-metadata.json"
     Then the CLI should fail with status code -1

--- a/csvcubed-pmd/tests/behaviour/dcatcommandline.feature
+++ b/csvcubed-pmd/tests/behaviour/dcatcommandline.feature
@@ -17,7 +17,7 @@ Feature: Testing the csvw command group in the CLI
     When the pmdutils command CLI is run with "dcat pmdify single-measure-bulletin.csv-metadata.json http://base-uri http://data-graph-uri http://catalog-metadata-graph-uri"
     Then the CLI should succeed
     And the file at "single-measure-bulletin.csv-metadata.json.nq" should exist
-    Given the RDF contained in "single-measure-bulletin.csv-metadata.json.nq"
+    Given the N-Quads contained in "single-measure-bulletin.csv-metadata.json.nq"
     Then the RDF should contain
     """
       @prefix dcat: <http://www.w3.org/ns/dcat#> .
@@ -61,7 +61,7 @@ Feature: Testing the csvw command group in the CLI
     When the pmdutils command CLI is run with "dcat pmdify single-measure-bulletin.csv-metadata.json http://base-uri http://data-graph-uri http://catalog-metadata-graph-uri"
     Then the CLI should succeed
     And the file at "single-measure-bulletin.csv-metadata.json.nq" should exist
-    Given the RDF contained in "single-measure-bulletin.csv-metadata.json.nq"
+    Given the N-Quads contained in "single-measure-bulletin.csv-metadata.json.nq"
     Then the RDF should contain
     """
       @prefix dcat: <http://www.w3.org/ns/dcat#> .
@@ -74,7 +74,7 @@ Feature: Testing the csvw command group in the CLI
     When the pmdutils command CLI is run with "dcat pmdify period.csv-metadata.json http://base-uri http://data-graph-uri http://catalog-metadata-graph-uri"
     Then the CLI should succeed
     And the file at "period.csv-metadata.json.nq" should exist
-    Given the RDF contained in "period.csv-metadata.json.nq"
+    Given the N-Quads contained in "period.csv-metadata.json.nq"
     Then the RDF should contain
     """
       @prefix dcat: <http://www.w3.org/ns/dcat#> .

--- a/csvcubed-pmd/tests/behaviour/dcatcommandline.feature
+++ b/csvcubed-pmd/tests/behaviour/dcatcommandline.feature
@@ -1,0 +1,83 @@
+Feature: Testing the csvw command group in the CLI
+
+  Scenario: The `pmdify` command should remove DCAT metadata from the CSV-W it is processing.
+    Given the existing test-case files "dcatcli/*"
+    When the pmdutils command CLI is run with "dcat pmdify single-measure-bulletin.csv-metadata.json http://base-uri http://data-graph-uri http://catalog-metadata-graph-uri"
+    Then the CLI should succeed
+    And csvlint validation of "single-measure-bulletin.csv-metadata.json" should succeed
+    And csv2rdf on "single-measure-bulletin.csv-metadata.json" should succeed
+    And the RDF should not contain any instances of "http://www.w3.org/ns/dcat#Dataset"
+    And the RDF should contain
+    """
+      <http://base-uri/single-measure-bulletin.csv#dataset> a <http://purl.org/linked-data/cube#DataSet>.
+    """
+
+  Scenario: The `pmdify` command should create a separate N-Quads file containing pmd-style catalog metadata.
+    Given the existing test-case files "dcatcli/*"
+    When the pmdutils command CLI is run with "dcat pmdify single-measure-bulletin.csv-metadata.json http://base-uri http://data-graph-uri http://catalog-metadata-graph-uri"
+    Then the CLI should succeed
+    And the file at "single-measure-bulletin.csv-metadata.json.nq" should exist
+    Given the RDF contained in "single-measure-bulletin.csv-metadata.json.nq"
+    Then the RDF should contain
+    """
+      @prefix dcat: <http://www.w3.org/ns/dcat#> .
+      @prefix dct: <http://purl.org/dc/terms/> .
+      @prefix pmdcat: <http://publishmydata.com/pmdcat#> .
+      @prefix void: <http://rdfs.org/ns/void#> .
+      @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+      <http://gss-data.org.uk/catalog/datasets> dcat:record <http://base-uri/single-measure-bulletin.csv#catalog-record> .
+
+      <http://base-uri/single-measure-bulletin.csv#catalog-entry> a pmdcat:Dataset;
+          rdfs:label "single-measure-bottles-bulletin"@en;
+          pmdcat:datasetContents <http://base-uri/single-measure-bulletin.csv#dataset>;
+          pmdcat:graph <http://data-graph-uri>;
+          pmdcat:metadataGraph <http://catalog-metadata-graph-uri>;
+          dct:creator <https://www.gov.uk/government/organisations/hm-revenue-customs>;
+          dct:description "All bulletins provide details on percentage of one litre or less bottles. This information is provided on a yearly basis."@en;
+          dct:identifier "single-measure-bottles-bulletin";
+          dct:issued "2019-02-28T00:00:00"^^xsd:dateTime;
+          dct:modified "2019-02-28T00:00:00"^^xsd:dateTime;
+          dct:publisher <https://www.gov.uk/government/organisations/hm-revenue-customs>;
+          dct:title "single-measure-bottles-bulletin"@en;
+          void:sparqlEndpoint <https://staging.gss-data.org.uk/sparql>;
+          dcat:keyword "keyword1"@en, "keyword2"@en;
+          dcat:landingPage <https://www.gov.uk/government/statistics/bottles-bulletin>;
+          dcat:theme <http://gss-data.org.uk/def/gdp#Trade>.
+
+      <http://base-uri/single-measure-bulletin.csv#catalog-record> a dcat:CatalogRecord;
+          rdfs:label "single-measure-bottles-bulletin"@en;
+          pmdcat:metadataGraph <http://catalog-metadata-graph-uri>;
+          dct:description "All bulletins provide details on percentage of one litre or less bottles. This information is provided on a yearly basis."@en;
+          dct:title "single-measure-bottles-bulletin"@en;
+          foaf:primaryTopic <http://base-uri/single-measure-bulletin.csv#catalog-entry> .
+    """
+
+
+   Scenario: The `pmdify` command should insert `qb:DataSet`s into the datasets catalogue.
+    Given the existing test-case files "dcatcli/*"
+    When the pmdutils command CLI is run with "dcat pmdify single-measure-bulletin.csv-metadata.json http://base-uri http://data-graph-uri http://catalog-metadata-graph-uri"
+    Then the CLI should succeed
+    And the file at "single-measure-bulletin.csv-metadata.json.nq" should exist
+    Given the RDF contained in "single-measure-bulletin.csv-metadata.json.nq"
+    Then the RDF should contain
+    """
+      @prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+      <http://gss-data.org.uk/catalog/datasets> dcat:record <http://base-uri/single-measure-bulletin.csv#catalog-record> .
+     """
+
+  Scenario: The `pmdify` command should insert `skos:ConceptSchemes`s into the vocabularies catalogue.
+    Given the existing test-case files "dcatcli/*"
+    When the pmdutils command CLI is run with "dcat pmdify period.csv-metadata.json http://base-uri http://data-graph-uri http://catalog-metadata-graph-uri"
+    Then the CLI should succeed
+    And the file at "period.csv-metadata.json.nq" should exist
+    Given the RDF contained in "period.csv-metadata.json.nq"
+    Then the RDF should contain
+    """
+      @prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+      <http://gss-data.org.uk/catalog/vocabularies> dcat:record <http://base-uri/period.csv#catalog-record> .
+     """

--- a/csvcubed-pmd/tests/test-cases/dcatcli/period.csv
+++ b/csvcubed-pmd/tests/test-cases/dcatcli/period.csv
@@ -1,0 +1,2 @@
+Label,Notation,Parent Notation,Sort Priority,Description,Original Concept URI
+2021,2021,,0,,http://reference.data.gov.uk/id/year/2021

--- a/csvcubed-pmd/tests/test-cases/dcatcli/period.csv-metadata.json
+++ b/csvcubed-pmd/tests/test-cases/dcatcli/period.csv-metadata.json
@@ -1,0 +1,46 @@
+{
+    "@context": "http://www.w3.org/ns/csvw",
+    "@id": "./period.csv#scheme/period",
+    "url": "period.csv",
+    "tableSchema": "period.table.json",
+    "rdfs:seeAlso": [
+        {
+            "@id": "./period.csv#scheme/period",
+            "@type": [
+                "http://www.w3.org/ns/dcat#Resource",
+                "http://www.w3.org/ns/dcat#Dataset",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/2004/02/skos/core#ConceptScheme"
+            ],
+            "http://purl.org/dc/terms/identifier": [
+                {
+                    "@value": "Period"
+                }
+            ],
+            "http://purl.org/dc/terms/issued": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2021-11-11T11:01:55.462050"
+                }
+            ],
+            "http://purl.org/dc/terms/modified": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2021-11-11T11:01:55.462050"
+                }
+            ],
+            "http://purl.org/dc/terms/title": [
+                {
+                    "@language": "en",
+                    "@value": "Period"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Period"
+                }
+            ]
+        }
+    ]
+}

--- a/csvcubed-pmd/tests/test-cases/dcatcli/period.table.json
+++ b/csvcubed-pmd/tests/test-cases/dcatcli/period.table.json
@@ -1,0 +1,59 @@
+{
+    "columns": [
+        {
+            "titles": "Label",
+            "name": "label",
+            "required": true,
+            "propertyUrl": "rdfs:label"
+        },
+        {
+            "titles": "Notation",
+            "name": "notation",
+            "required": true,
+            "propertyUrl": "skos:notation"
+        },
+        {
+            "titles": "Parent Notation",
+            "name": "parent_notation",
+            "required": false,
+            "propertyUrl": "skos:broader",
+            "valueUrl": "./period.csv#concept/period/{+parent_notation}"
+        },
+        {
+            "titles": "Sort Priority",
+            "name": "sort_priority",
+            "required": false,
+            "datatype": "integer",
+            "propertyUrl": "http://www.w3.org/ns/ui#sortPriority"
+        },
+        {
+            "titles": "Description",
+            "name": "description",
+            "required": false,
+            "propertyUrl": "rdfs:comment"
+        },
+        {
+            "titles": "Original Concept URI",
+            "name": "uri",
+            "required": true,
+            "propertyUrl": "owl:sameAs",
+            "valueUrl": "{+uri}"
+        },
+        {
+            "virtual": true,
+            "name": "virt_inScheme",
+            "required": true,
+            "propertyUrl": "skos:inScheme",
+            "valueUrl": "./period.csv#scheme/period"
+        },
+        {
+            "virtual": true,
+            "name": "virt_type",
+            "required": true,
+            "propertyUrl": "rdf:type",
+            "valueUrl": "skos:Concept"
+        }
+    ],
+    "aboutUrl": "./period.csv#concept/period/{+notation}",
+    "primaryKey": "notation"
+}

--- a/csvcubed-pmd/tests/test-cases/dcatcli/single-measure-bulletin.csv
+++ b/csvcubed-pmd/tests/test-cases/dcatcli/single-measure-bulletin.csv
@@ -1,0 +1,2 @@
+Period,Value,Marker
+2021,40,provisional

--- a/csvcubed-pmd/tests/test-cases/dcatcli/single-measure-bulletin.csv-metadata.json
+++ b/csvcubed-pmd/tests/test-cases/dcatcli/single-measure-bulletin.csv-metadata.json
@@ -1,0 +1,400 @@
+{
+    "@context": "http://www.w3.org/ns/csvw",
+    "@id": "single-measure-bulletin.csv#dataset",
+    "tables": [
+        {
+            "url": "single-measure-bulletin.csv",
+            "tableSchema": {
+                "columns": [
+                    {
+                        "titles": "Period",
+                        "name": "period",
+                        "propertyUrl": "single-measure-bulletin.csv#dimension/period",
+                        "valueUrl": "period.csv#concept/period/{+period}",
+                        "required": true
+                    },
+                    {
+                        "titles": "Value",
+                        "name": "value",
+                        "propertyUrl": "single-measure-bulletin.csv#measure/one-litre-and-less",
+                        "datatype": "integer",
+                        "required": true
+                    },
+                    {
+                        "titles": "Marker",
+                        "name": "marker",
+                        "propertyUrl": "single-measure-bulletin.csv#attribute/marker",
+                        "valueUrl": "single-measure-bulletin.csv#attribute/marker/{+marker}",
+                        "required": false
+                    },
+                    {
+                        "name": "virt_unit",
+                        "virtual": true,
+                        "propertyUrl": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure",
+                        "valueUrl": "http://gss-data.org.uk/def/concept/measurement-units/percentage"
+                    },
+                    {
+                        "name": "virt_measure",
+                        "virtual": true,
+                        "propertyUrl": "http://purl.org/linked-data/cube#measureType",
+                        "valueUrl": "single-measure-bulletin.csv#measure/one-litre-and-less"
+                    }
+                ],
+                "foreignKeys": [
+                    {
+                        "columnReference": "period",
+                        "reference": {
+                            "resource": "period.csv",
+                            "columnReference": "notation"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "period"
+                ],
+                "aboutUrl": "single-measure-bulletin.csv#obs/{+period}"
+            }
+        },
+        {
+            "url": "period.csv",
+            "tableSchema": "period.table.json",
+            "suppressOutput": true
+        }
+    ],
+    "rdfs:seeAlso": [
+        {
+            "@id": "single-measure-bulletin.csv#dataset",
+            "@type": [
+                "http://www.w3.org/ns/dcat#Dataset",
+                "http://www.w3.org/ns/dcat#Resource",
+                "http://purl.org/linked-data/cube#DataSet",
+                "http://purl.org/linked-data/cube#Attachable",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ],
+            "http://purl.org/dc/terms/creator": [
+                {
+                    "@id": "https://www.gov.uk/government/organisations/hm-revenue-customs"
+                }
+            ],
+            "http://purl.org/dc/terms/description": [
+                {
+                    "@language": "en",
+                    "@value": "All bulletins provide details on percentage of one litre or less bottles. This information is provided on a yearly basis."
+                }
+            ],
+            "http://purl.org/dc/terms/identifier": [
+                {
+                    "@value": "single-measure-bottles-bulletin"
+                }
+            ],
+            "http://purl.org/dc/terms/issued": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2019-02-28T00:00:00"
+                }
+            ],
+            "http://purl.org/dc/terms/modified": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2019-02-28T00:00:00"
+                }
+            ],
+            "http://purl.org/dc/terms/publisher": [
+                {
+                    "@id": "https://www.gov.uk/government/organisations/hm-revenue-customs"
+                }
+            ],
+            "http://purl.org/dc/terms/title": [
+                {
+                    "@language": "en",
+                    "@value": "single-measure-bottles-bulletin"
+                }
+            ],
+            "http://purl.org/linked-data/cube#structure": [
+                {
+                    "@id": "single-measure-bulletin.csv#structure"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "single-measure-bottles-bulletin"
+                }
+            ],
+            "http://www.w3.org/ns/dcat#landingPage": [
+                {
+                    "@id": "https://www.gov.uk/government/statistics/bottles-bulletin"
+                }
+            ],
+            "http://www.w3.org/ns/dcat#theme": [
+                {
+                    "@id": "http://gss-data.org.uk/def/gdp#Trade"
+                }
+            ],
+            "rdfs:comment": {
+                "@language": "en",
+                "@value": "some comment goes here"
+            },
+            "http://purl.org/dc/terms/license": {
+                "@id": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+            },
+            "http://www.w3.org/ns/dcat#contactPoint": {
+                "@id": "mailto:something@example.com"
+            },
+            "http://www.w3.org/ns/dcat#keyword": ["keyword 1", "keyword 2"]
+        },
+        {
+            "@id": "single-measure-bulletin.csv#component/period",
+            "@type": [
+                "http://purl.org/linked-data/cube#ComponentSpecification",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "single-measure-bulletin.csv#dimension/period"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "single-measure-bulletin.csv#dimension/period"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 1
+                }
+            ]
+        },
+        {
+            "@id": "single-measure-bulletin.csv#attribute/marker",
+            "@type": [
+                "http://purl.org/linked-data/cube#AttributeProperty",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#ComponentProperty"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Marker"
+                }
+            ]
+        },
+        {
+            "@id": "single-measure-bulletin.csv#structure",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#DataStructureDefinition"
+            ],
+            "http://purl.org/linked-data/cube#component": [
+                {
+                    "@id": "single-measure-bulletin.csv#component/unit"
+                },
+                {
+                    "@id": "single-measure-bulletin.csv#component/marker"
+                },
+                {
+                    "@id": "single-measure-bulletin.csv#component/one-litre-and-less"
+                },
+                {
+                    "@id": "single-measure-bulletin.csv#component/measure-type"
+                },
+                {
+                    "@id": "single-measure-bulletin.csv#component/period"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                },
+                {
+                    "@id": "single-measure-bulletin.csv#attribute/marker"
+                },
+                {
+                    "@id": "single-measure-bulletin.csv#measure/one-litre-and-less"
+                },
+                {
+                    "@id": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure"
+                },
+                {
+                    "@id": "single-measure-bulletin.csv#dimension/period"
+                }
+            ]
+        },
+        {
+            "@id": "single-measure-bulletin.csv#component/measure-type",
+            "@type": [
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 2
+                }
+            ]
+        },
+        {
+            "@id": "single-measure-bulletin.csv#component/one-litre-and-less",
+            "@type": [
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "single-measure-bulletin.csv#measure/one-litre-and-less"
+                }
+            ],
+            "http://purl.org/linked-data/cube#measure": [
+                {
+                    "@id": "single-measure-bulletin.csv#measure/one-litre-and-less"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 4
+                }
+            ]
+        },
+        {
+            "@id": "single-measure-bulletin.csv#class/period",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Class",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ]
+        },
+        {
+            "@id": "single-measure-bulletin.csv#measure/one-litre-and-less",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#MeasureProperty",
+                "http://purl.org/linked-data/cube#ComponentProperty"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "One litre and less"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                }
+            ]
+        },
+        {
+            "@id": "single-measure-bulletin.csv#dimension/period",
+            "@type": [
+                "http://purl.org/linked-data/cube#ComponentProperty",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#DimensionProperty",
+                "http://purl.org/linked-data/cube#CodedProperty",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ],
+            "http://purl.org/linked-data/cube#codeList": [
+                {
+                    "@id": "period.csv#scheme/period"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Period"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "single-measure-bulletin.csv#class/period"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+                {
+                    "@id": "http://purl.org/linked-data/sdmx/2009/dimension#refPeriod"
+                }
+            ]
+        },
+        {
+            "@id": "single-measure-bulletin.csv#component/marker",
+            "@type": [
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ],
+            "http://purl.org/linked-data/cube#attribute": [
+                {
+                    "@id": "single-measure-bulletin.csv#attribute/marker"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "single-measure-bulletin.csv#attribute/marker"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentRequired": [
+                {
+                    "@value": false
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 5
+                }
+            ]
+        },
+        {
+            "@id": "single-measure-bulletin.csv#component/unit",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSpecification",
+                "http://purl.org/linked-data/cube#ComponentSet"
+            ],
+            "http://purl.org/linked-data/cube#attribute": [
+                {
+                    "@id": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentRequired": [
+                {
+                    "@value": true
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 3
+                }
+            ]
+        },
+        {
+            "@id": "single-measure-bulletin.csv#attribute/marker/provisional",
+            "@type": [
+                "http://www.w3.org/2004/02/skos/core#Concept",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Provisional"
+                }
+            ]
+        }
+    ]
+}

--- a/csvcubed-pmd/tests/test-cases/dcatcli/single-measure-bulletin.csv-metadata.json
+++ b/csvcubed-pmd/tests/test-cases/dcatcli/single-measure-bulletin.csv-metadata.json
@@ -121,17 +121,27 @@
                     "@value": "single-measure-bottles-bulletin"
                 }
             ],
+            "http://www.w3.org/2000/01/rdf-schema#comment": {
+                "@language": "en",
+                "@value": "some comment goes here"
+            },
             "http://www.w3.org/ns/dcat#landingPage": [
                 {
                     "@id": "https://www.gov.uk/government/statistics/bottles-bulletin"
                 }
             ],
+            "http://purl.org/dc/terms/license": {
+                "@id": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+            },
             "http://www.w3.org/ns/dcat#theme": [
                 {
                     "@id": "http://gss-data.org.uk/def/gdp#Trade"
                 }
             ],
-            "http://www.w3.org/ns/dcat#keyword": [ "keyword1", "keyword2"]
+            "http://www.w3.org/ns/dcat#keyword": [ "keyword1", "keyword2"],
+            "http://www.w3.org/ns/dcat#contactPoint": {
+                "@id": "mailto:something@example.com"
+            }
         },
         {
             "@id": "single-measure-bulletin.csv#component/period",

--- a/csvcubed-pmd/tests/test-cases/dcatcli/single-measure-bulletin.csv-metadata.json
+++ b/csvcubed-pmd/tests/test-cases/dcatcli/single-measure-bulletin.csv-metadata.json
@@ -131,17 +131,7 @@
                     "@id": "http://gss-data.org.uk/def/gdp#Trade"
                 }
             ],
-            "rdfs:comment": {
-                "@language": "en",
-                "@value": "some comment goes here"
-            },
-            "http://purl.org/dc/terms/license": {
-                "@id": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            },
-            "http://www.w3.org/ns/dcat#contactPoint": {
-                "@id": "mailto:something@example.com"
-            },
-            "http://www.w3.org/ns/dcat#keyword": ["keyword 1", "keyword 2"]
+            "http://www.w3.org/ns/dcat#keyword": [ "keyword1", "keyword2"]
         },
         {
             "@id": "single-measure-bulletin.csv#component/period",

--- a/csvcubed-pmd/tests/unit/dcatcli/test_pmdify.py
+++ b/csvcubed-pmd/tests/unit/dcatcli/test_pmdify.py
@@ -51,7 +51,7 @@ def test_extracting_metadata():
         == "https://www.gov.uk/government/statistics/bottles-bulletin"
     )
     assert existing_dcat_dataset.themes == {"http://gss-data.org.uk/def/gdp#Trade"}
-    assert existing_dcat_dataset.keywords == {"keyword 1", "keyword 2"}
+    assert existing_dcat_dataset.keywords == {"keyword1", "keyword2"}
     assert existing_dcat_dataset.contact_point == "mailto:something@example.com"
     assert existing_dcat_dataset.identifier == "single-measure-bottles-bulletin"
 

--- a/csvcubed-pmd/tests/unit/dcatcli/test_pmdify.py
+++ b/csvcubed-pmd/tests/unit/dcatcli/test_pmdify.py
@@ -11,15 +11,6 @@ from csvcubedpmd.models.CsvCubedOutputType import CsvCubedOutputType
 _TEST_CASES_DIR = get_test_cases_dir() / "dcatcli"
 
 
-def test_thingy():
-    pmdify.pmdify_dcat(
-        _TEST_CASES_DIR / "single-measure-bulletin.csv-metadata.json",
-        "http://base-url",
-        "http://something",
-        "http://something-else",
-    )
-
-
 def test_extracting_metadata():
     """
     Test we can successfully extract the metadata from a `dcat:Dataset` inside a CSV-W.

--- a/csvcubed-pmd/tests/unit/dcatcli/test_pmdify.py
+++ b/csvcubed-pmd/tests/unit/dcatcli/test_pmdify.py
@@ -1,0 +1,101 @@
+import datetime
+
+import pytest
+from rdflib import Graph
+from csvcubeddevtools.helpers.file import get_test_cases_dir
+
+
+from csvcubedpmd.dcatcli import pmdify
+from csvcubedpmd.models.CsvCubedOutputType import CsvCubedOutputType
+
+_TEST_CASES_DIR = get_test_cases_dir() / "dcatcli"
+
+
+def test_extracting_metadata():
+    """
+    Test we can successfully extract the metadata from a `dcat:Dataset` inside a CSV-W.
+    """
+    csvw_graph = Graph()
+    csvw_graph.parse(
+        str(_TEST_CASES_DIR / "single-measure-bulletin.csv-metadata.json"),
+        format="json-ld",
+    )
+
+    existing_dcat_dataset = pmdify._get_catalog_entry_from_dcat_dataset(csvw_graph)
+
+    assert existing_dcat_dataset is not None
+    assert existing_dcat_dataset.title == "single-measure-bottles-bulletin"
+    assert existing_dcat_dataset.label == "single-measure-bottles-bulletin"
+    assert existing_dcat_dataset.issued == datetime.datetime(2019, 2, 28)
+    assert existing_dcat_dataset.modified == datetime.datetime(2019, 2, 28)
+    assert existing_dcat_dataset.comment == "some comment goes here"
+    assert (
+        existing_dcat_dataset.description
+        == "All bulletins provide details on percentage of one litre or less bottles. This information is provided"
+        + " on a yearly basis."
+    )
+    assert (
+        existing_dcat_dataset.license
+        == "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+    )
+    assert (
+        existing_dcat_dataset.creator
+        == "https://www.gov.uk/government/organisations/hm-revenue-customs"
+    )
+    assert (
+        existing_dcat_dataset.publisher
+        == "https://www.gov.uk/government/organisations/hm-revenue-customs"
+    )
+    assert (
+        existing_dcat_dataset.landing_page
+        == "https://www.gov.uk/government/statistics/bottles-bulletin"
+    )
+    assert existing_dcat_dataset.themes == {"http://gss-data.org.uk/def/gdp#Trade"}
+    assert existing_dcat_dataset.keywords == {"keyword 1", "keyword 2"}
+    assert existing_dcat_dataset.contact_point == "mailto:something@example.com"
+    assert existing_dcat_dataset.identifier == "single-measure-bottles-bulletin"
+
+
+def test_delete_dcat_metadata():
+    csvw_graph = Graph()
+    csvw_graph.parse(
+        str(_TEST_CASES_DIR / "single-measure-bulletin.csv-metadata.json"),
+        format="json-ld",
+    )
+
+    existing_dcat_dataset = pmdify._get_catalog_entry_from_dcat_dataset(csvw_graph)
+    assert existing_dcat_dataset is not None
+
+    pmdify._delete_existing_dcat_dataset_metadata(csvw_graph)
+
+    with pytest.raises(Exception) as exception:
+        pmdify._get_catalog_entry_from_dcat_dataset(csvw_graph)
+    assert str(exception.value) == "Expected 1 dcat:Dataset record, found 0"
+
+
+def test_identification_of_csvcubed_output_type():
+    csvw_graph = Graph()
+    csvw_graph.parse(
+        str(_TEST_CASES_DIR / "single-measure-bulletin.csv-metadata.json"),
+        format="json-ld",
+    )
+    actual_output_type = pmdify._get_csv_cubed_output_type(csvw_graph)
+
+    assert actual_output_type == CsvCubedOutputType.QbDataSet
+
+    # todo: Need to test a skos:ConceptScheme here too
+
+
+def test_catalog_uris_for_csvcubed_output_types():
+    assert (
+        pmdify._get_catalog_uri_to_add_to(CsvCubedOutputType.SkosConceptScheme)
+        == "http://gss-data.org.uk/catalog/vocabularies"
+    )
+    assert (
+        pmdify._get_catalog_uri_to_add_to(CsvCubedOutputType.QbDataSet)
+        == "http://gss-data.org.uk/catalog/datasets"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/csvcubed-pmd/tests/unit/dcatcli/test_pmdify.py
+++ b/csvcubed-pmd/tests/unit/dcatcli/test_pmdify.py
@@ -11,6 +11,15 @@ from csvcubedpmd.models.CsvCubedOutputType import CsvCubedOutputType
 _TEST_CASES_DIR = get_test_cases_dir() / "dcatcli"
 
 
+def test_thingy():
+    pmdify.pmdify_dcat(
+        _TEST_CASES_DIR / "single-measure-bulletin.csv-metadata.json",
+        "http://base-url",
+        "http://something",
+        "http://something-else",
+    )
+
+
 def test_extracting_metadata():
     """
     Test we can successfully extract the metadata from a `dcat:Dataset` inside a CSV-W.
@@ -74,6 +83,7 @@ def test_delete_dcat_metadata():
 
 
 def test_identification_of_csvcubed_output_type():
+    # Test `qb:DataSet` can be correctly identified.
     csvw_graph = Graph()
     csvw_graph.parse(
         str(_TEST_CASES_DIR / "single-measure-bulletin.csv-metadata.json"),
@@ -83,7 +93,15 @@ def test_identification_of_csvcubed_output_type():
 
     assert actual_output_type == CsvCubedOutputType.QbDataSet
 
-    # todo: Need to test a skos:ConceptScheme here too
+    # Test `skos:ConceptScheme` can be correctly identified.
+    csvw_graph = Graph()
+    csvw_graph.parse(
+        str(_TEST_CASES_DIR / "period.csv-metadata.json"),
+        format="json-ld",
+    )
+    actual_output_type = pmdify._get_csv_cubed_output_type(csvw_graph)
+
+    assert actual_output_type == CsvCubedOutputType.SkosConceptScheme
 
 
 def test_catalog_uris_for_csvcubed_output_types():


### PR DESCRIPTION
Added a new CLI command which strips out the DCAT catalog metadata out of the `file.csv-metadata.json` file and drops it into a `file.csv-metadata.json.nq` N-Quads file.

```
$ pmdutils dcat pmdify --help
Usage: pmdutils dcat pmdify [OPTIONS] CSVW_METADATA_FILE BASE_URI
                            DATA_GRAPH_URI CATALOG_METADATA_GRAPH_URI

  Given a local CSV-W metadata.json file, re-work the DCATv2 metadata such
  that it ends up in the format required for PMD.

  Removes the expected DCAT metadata from the CSV-W metadata.json file and
  outputs a new N-Quads file containing PMDCAT metadata at
  <CSVW_METADATA_FILE>.nq
``` 


* `CSVW_METADATA_FILE` - the `.csv-metadata.json` CSV-W file.
* `BASE_URI` - the base URI which URIs inside the CSV-W are relative to (generally the URL of the directory holding the CSV-W).
* `DATA_GRAPH_URI` - the graph URI which the `skos:ConceptScheme`/`qb:DataSet` in to be held within.
* `CATALOG_METADATA_GRAPH_URI` - the graph URI which the DCAT metadata will be uploaded to.

Satisfies Issue #105