### PR TITLE
Issue #105 - Adding CLI Command to find CSV-W files matching SPARQL ASK query

### DIFF
--- a/csvcubed-pmd/csvcubedpmd/csvwcli/__init__.py
+++ b/csvcubed-pmd/csvcubedpmd/csvwcli/__init__.py
@@ -54,6 +54,6 @@ def _pull(out: Path, csvw_url: str):
 )
 def _find_where(inside: Path, negate: bool, ask_query: str):
     """
-    Find all CSV-W metadata files in within a given directory which match an ASK query.
+    Find all CSV-W metadata files within a given directory which match an ASK query.
     """
     findwhere.find_where(inside, ask_query, negate)

--- a/csvcubed-pmd/csvcubedpmd/csvwcli/__init__.py
+++ b/csvcubed-pmd/csvcubedpmd/csvwcli/__init__.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import click
 
-import csvcubedpmd.csvwcli.pull as pull
+from csvcubedpmd.csvwcli import pull, findwhere
 
 
 @click.group("csvw")
@@ -32,3 +32,28 @@ def _pull(out: Path, csvw_url: str):
     Pull a CSV-W and all relative dependencies to the local filesystem.
     """
     pull.pull(csvw_url, out.absolute())
+
+
+@csvw_group.command("find-where")
+@click.option(
+    "--inside",
+    "-i",
+    help="Directory in which to search for CSV-W Metadata Files",
+    type=click.Path(exists=True, path_type=Path, file_okay=False, dir_okay=True),
+    default=".",
+    show_default=True,
+    metavar="SEARCH_DIR",
+)
+@click.option(
+    "--negate", "-n", help="Negate the result of running the ASK query.", is_flag=True
+)
+@click.argument(
+    "ask_query",
+    type=click.STRING,
+    metavar="ASK_QUERY",
+)
+def _find_where(inside: Path, negate: bool, ask_query: str):
+    """
+    Find all CSV-W metadata files in within a given directory which match an ASK query.
+    """
+    findwhere.find_where(inside, ask_query, negate)

--- a/csvcubed-pmd/csvcubedpmd/csvwcli/findwhere.py
+++ b/csvcubed-pmd/csvcubedpmd/csvwcli/findwhere.py
@@ -1,0 +1,27 @@
+"""
+Find Where
+----------
+
+Allows you to find CSV-W metadata files in a directory (or sub-directories) which match a given SPARQL ASK
+Query.
+"""
+from pathlib import Path
+from rdflib import Graph
+from typing import List
+
+from csvcubedpmd.utils.sparql import ask
+
+
+def find_where(find_location: Path, ask_query: str, negate: bool) -> None:
+    """
+    Find all CSV-Ws inside a directory which match the provided :obj:`ask_query`.
+    """
+    matching_csvws: List[Path] = []
+    for csvw_metadata_file in find_location.rglob("**/*csv-metadata.json"):
+        graph_data = Graph()
+        graph_data.load(str(csvw_metadata_file), format="json-ld")
+        if ask(ask_query, graph_data) != negate:
+            matching_csvws.append(csvw_metadata_file)
+
+    for matching_csvw_path in matching_csvws:
+        print(str(matching_csvw_path))

--- a/csvcubed-pmd/csvcubedpmd/dcatcli/pmdify.py
+++ b/csvcubed-pmd/csvcubedpmd/dcatcli/pmdify.py
@@ -21,6 +21,7 @@ from rdflib.term import Identifier
 from csvcubedpmd.config import pmdconfig
 from csvcubedpmd.models.CsvCubedOutputType import CsvCubedOutputType
 from csvcubedpmd.models.rdf import pmdcat
+from csvcubedpmd.utils.sparql import ask
 
 _TEMP_PREFIX_URI = URIRef("http://temporary")
 
@@ -304,7 +305,7 @@ def _none_or_map(val: Optional[Any], map_func: Callable[[Any], Any]) -> Optional
 
 
 def _get_csv_cubed_output_type(csvw_rdf_graph: Graph) -> CsvCubedOutputType:
-    is_concept_scheme = _ask_query(
+    is_concept_scheme = ask(
         """
         ASK 
         WHERE {
@@ -317,7 +318,7 @@ def _get_csv_cubed_output_type(csvw_rdf_graph: Graph) -> CsvCubedOutputType:
     if is_concept_scheme:
         return CsvCubedOutputType.SkosConceptScheme
 
-    is_qb_dataset = _ask_query(
+    is_qb_dataset = ask(
         """
         ASK 
         WHERE {
@@ -333,16 +334,3 @@ def _get_csv_cubed_output_type(csvw_rdf_graph: Graph) -> CsvCubedOutputType:
     raise Exception(
         f"Could not determine {CsvCubedOutputType.__name__} for input CSV-W graph."
     )
-
-
-def _ask_query(query: str, graph: Graph) -> bool:
-    results = list(graph.query(query))
-
-    if len(results) == 1:
-        result = results[0]
-        if isinstance(result, bool):
-            return result
-        else:
-            raise Exception(f"Unexpected ASK query response type {type(result)}")
-    else:
-        raise Exception(f"Unexpected number of results for ASK query {len(results)}.")

--- a/csvcubed-pmd/csvcubedpmd/main.py
+++ b/csvcubed-pmd/csvcubedpmd/main.py
@@ -6,6 +6,26 @@ import click
 
 from csvcubedpmd import csvwcli, dcatcli
 
+
+def _suppress_rdf_lib_json_ld_import_warning():
+    """
+    Unfortunately, the current version of rdflib-jsonld library issued a warning that they seem to insist users see.
+
+    Here's some hacky code to make sure the user never sees it.
+    """
+    import io
+    import sys
+
+    initial_std_err = sys.stderr
+    try:
+        sys.stderr = io.StringIO()
+        import rdflib_jsonld
+    finally:
+        sys.stderr = initial_std_err
+
+
+_suppress_rdf_lib_json_ld_import_warning()
+
 entry_point = click.Group(
     commands=[csvwcli.csvw_group, dcatcli.dcat_group],
     help="pmdutils - Utils for helping convert CSV-Ws to PMD-compatible RDF.",

--- a/csvcubed-pmd/csvcubedpmd/utils/sparql.py
+++ b/csvcubed-pmd/csvcubedpmd/utils/sparql.py
@@ -1,0 +1,20 @@
+"""
+SPARQL
+------
+
+Utilities to help when running SPARQL queries.
+"""
+from rdflib import Graph
+
+
+def ask(query: str, graph: Graph) -> bool:
+    results = list(graph.query(query))
+
+    if len(results) == 1:
+        result = results[0]
+        if isinstance(result, bool):
+            return result
+        else:
+            raise Exception(f"Unexpected ASK query response type {type(result)}")
+    else:
+        raise Exception(f"Unexpected number of results for ASK query {len(results)}.")

--- a/csvcubed-pmd/tests/behaviour/csvwcommandline.feature
+++ b/csvcubed-pmd/tests/behaviour/csvwcommandline.feature
@@ -57,7 +57,18 @@ Feature: Testing the csvw command group in the CLI
     And the file at "out/junior-roles.csv" should exist
     And the file at "out/gov.uk/schema/junior-roles.json" should exist
 
-
     Scenario: The `pull` command should fail when the CSV-W file cannot be found.
     When the pmdutils command CLI is run with "csvw pull https://example.com/non-existant-file.csv-metadata.json"
     Then the CLI should fail with status code -1
+
+    Scenario: The `find-where` command should find return CSV-Ws matching an ASK query.
+    Given the existing test-case files "dcatcli/*"
+    When the pmdutils command CLI is run with "csvw find-where 'ASK WHERE { ?s a <http://www.w3.org/2004/02/skos/core#ConceptScheme>. }'"
+    Then the CLI should succeed
+    And the CLI should print "period.csv-metadata.json"
+
+    Scenario: The `find-where` command should return CSV-Ws which do *not* match an ASK query when the negate option is set
+    Given the existing test-case files "dcatcli/*"
+    When the pmdutils command CLI is run with "csvw find-where --negate 'ASK WHERE { ?s a <http://www.w3.org/2004/02/skos/core#ConceptScheme>. }'"
+    Then the CLI should succeed
+    And the CLI should print "single-measure-bulletin.csv-metadata.json"


### PR DESCRIPTION
```bash
$ pmdutils csvw find-where --help
Usage: pmdutils csvw find-where [OPTIONS] ASK_QUERY

  Find all CSV-W metadata files within a given directory which match an ASK
  query.

Options:
  -i, --inside SEARCH_DIR  Directory in which to search for CSV-W Metadata
                           Files  [default: .]
  -n, --negate             Negate the result of running the ASK query.
  -h, --help               Show this message and exit.
```

example usage:

```bash
 $ pmdutils csvw find-where "ASK WHERE { ?s a <http://www.w3.org/2004/02/skos/core#ConceptScheme>. }"
tests/test-cases/dcatcli/period.csv-metadata.json
```