### PR TITLE
Fixing bug where `pmdcat` datatype wasn't added to the `qb:DataSet` or `skos:ConceptScheme` which had been added to a catalog.

### DIFF
--- a/csvcubed-devtools/csvcubeddevtools/behaviour/rdf.py
+++ b/csvcubed-devtools/csvcubeddevtools/behaviour/rdf.py
@@ -21,9 +21,9 @@ def test_graph_diff(g1, g2):
         len(only_in_second) == 0
     ), f"""
         <<<
-        {only_in_first.serialize(format='n3').decode('utf-8')}
+        {rdflibhelpers.serialise_to_string(only_in_first, format='n3')}
         ===
-        {only_in_second.serialize(format='n3').decode('utf-8')}
+        {rdflibhelpers.serialise_to_string(only_in_second, format='n3')}
         >>>
         """
 

--- a/csvcubed-pmd/csvcubedpmd/dcatcli/pmdify.py
+++ b/csvcubed-pmd/csvcubedpmd/dcatcli/pmdify.py
@@ -84,7 +84,9 @@ def pmdify_dcat(
     )
 
 
-def _set_pmdcat_type_on_dataset_contents(csvw_rdf_graph, csvw_type):
+def _set_pmdcat_type_on_dataset_contents(
+    csvw_rdf_graph: Graph, csvw_type: CsvCubedOutputType
+) -> None:
     if csvw_type == CsvCubedOutputType.QbDataSet:
         csvw_rdf_graph.update(
             """           

--- a/csvcubed-pmd/csvcubedpmd/dcatcli/pmdify.py
+++ b/csvcubed-pmd/csvcubedpmd/dcatcli/pmdify.py
@@ -58,6 +58,8 @@ def pmdify_dcat(
 
     _delete_existing_dcat_dataset_metadata(csvw_rdf_graph)
 
+    _set_pmdcat_type_on_dataset_contents(csvw_rdf_graph, csvw_type)
+
     _replace_uri_substring_in_graph(csvw_rdf_graph, str(_TEMP_PREFIX_URI), base_uri)
     csvw_file_contents_json["rdfs:seeAlso"] = rdflibutils.serialise_to_json_ld(
         csvw_rdf_graph
@@ -80,6 +82,29 @@ def pmdify_dcat(
         catalog_metadata_graph_uri,
         base_uri,
     )
+
+
+def _set_pmdcat_type_on_dataset_contents(csvw_rdf_graph, csvw_type):
+    if csvw_type == CsvCubedOutputType.QbDataSet:
+        csvw_rdf_graph.update(
+            """           
+            PREFIX qb:      <http://purl.org/linked-data/cube#>
+            PREFIX pmdcat:  <http://publishmydata.com/pmdcat#>
+
+            INSERT { ?dataset a pmdcat:Dataset. } WHERE { ?dataset a qb:DataSet. }
+            """
+        )
+    elif csvw_type == CsvCubedOutputType.SkosConceptScheme:
+        csvw_rdf_graph.update(
+            """
+            PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+            PREFIX pmdcat:  <http://publishmydata.com/pmdcat#>
+
+            INSERT { ?dataset a pmdcat:ConceptScheme. } WHERE { ?dataset a skos:ConceptScheme. }
+            """
+        )
+    else:
+        raise Exception(f"Unmatched CSV-W type '{csvw_type}'")
 
 
 def _replace_uri_substring_in_graph(

--- a/csvcubed-pmd/tests/behaviour/dcatcommandline.feature
+++ b/csvcubed-pmd/tests/behaviour/dcatcommandline.feature
@@ -9,7 +9,30 @@ Feature: Testing the csvw command group in the CLI
     And the RDF should not contain any instances of "http://www.w3.org/ns/dcat#Dataset"
     And the RDF should contain
     """
-      <http://base-uri/single-measure-bulletin.csv#dataset> a <http://purl.org/linked-data/cube#DataSet>.
+      <http://base-uri/single-measure-bulletin.csv#dataset> a <http://purl.org/linked-data/cube#DataSet>,
+                                                              # the qb:Dataset needs to be a pmdcat:Dataset too since
+                                                              # it's referenced by a catalog record.
+                                                              <http://publishmydata.com/pmdcat#Dataset>.
+    """
+
+  Scenario: The `pmdify` command should add the `pmdcat:Dataset` type to `qb:DataSet`s
+    Given the existing test-case files "dcatcli/*"
+    When the pmdutils command CLI is run with "dcat pmdify single-measure-bulletin.csv-metadata.json http://base-uri http://data-graph-uri http://catalog-metadata-graph-uri"
+    Then the CLI should succeed
+    And csv2rdf on "single-measure-bulletin.csv-metadata.json" should succeed
+    And the RDF should contain
+    """
+      <http://base-uri/single-measure-bulletin.csv#dataset> a <http://publishmydata.com/pmdcat#Dataset>.
+    """
+
+  Scenario: The `pmdify` command should add the `pmdcat:ConceptScheme` type to `skos:ConceptScheme`s
+    Given the existing test-case files "dcatcli/*"
+    When the pmdutils command CLI is run with "dcat pmdify period.csv-metadata.json http://base-uri http://data-graph-uri http://catalog-metadata-graph-uri"
+    Then the CLI should succeed
+    And csv2rdf on "period.csv-metadata.json" should succeed
+    And the RDF should contain
+    """
+      <http://base-uri/period.csv#scheme/period> a <http://publishmydata.com/pmdcat#ConceptScheme>.
     """
 
   Scenario: The `pmdify` command should create a separate N-Quads file containing pmd-style catalog metadata.


### PR DESCRIPTION
This is a requirement PMD imposes on the data we upload to it.