### PR TITLE
Fixing bug in integer serialisation to CSV

### DIFF
--- a/csvcubed/csvcubed/utils/qb/standardise.py
+++ b/csvcubed/csvcubed/utils/qb/standardise.py
@@ -76,6 +76,7 @@ def ensure_int_columns_are_ints(cube: QbCube) -> None:
         return
 
     def _coerce_to_int_values_if_int(column_title: str, data_type: str):
+        assert cube.data is not None
         if data_type in _signed_integer_data_types:
             cube.data[column_title] = cube.data[column_title].astype(pd.Int64Dtype())
         elif data_type in _unsigned_integer_data_types:

--- a/csvcubed/csvcubed/writers/qbwriter.py
+++ b/csvcubed/csvcubed/writers/qbwriter.py
@@ -32,7 +32,10 @@ from csvcubed.utils.qb.cube import (
     QbColumnarDsdType,
 )
 from csvcubed.utils.dict import rdf_resource_to_json_ld
-from csvcubed.utils.qb.standardise import convert_data_values_to_uri_safe_values
+from csvcubed.utils.qb.standardise import (
+    convert_data_values_to_uri_safe_values,
+    ensure_int_columns_are_ints,
+)
 from csvcubed.utils.file import copy_files_to_directory_with_structure
 from .skoscodelistwriter import (
     SkosCodeListWriter,
@@ -83,6 +86,8 @@ class QbWriter(WriterBase):
         # Also converts all appropriate columns to the pandas categorical format.
 
         _logger.info("Beginning CSV-W Generation")
+
+        ensure_int_columns_are_ints(self.cube)
 
         convert_data_values_to_uri_safe_values(
             self.cube, self.raise_missing_uri_safe_value_exceptions

--- a/csvcubed/tests/unit/utils/qb/test_standardise.py
+++ b/csvcubed/tests/unit/utils/qb/test_standardise.py
@@ -1,3 +1,4 @@
+import math
 import pandas as pd
 import pytest
 from pandas.core.arrays.categorical import Categorical
@@ -12,6 +13,7 @@ from csvcubed.models.cube import (
 from csvcubed.utils.qb.standardise import (
     ensure_qbcube_data_is_categorical,
     convert_data_values_to_uri_safe_values,
+    ensure_int_columns_are_ints,
 )
 
 
@@ -212,6 +214,114 @@ def test_qbcube_catagorical_numeric():
     for column_name in expected_non_categorical_columns:
         values = cube.data[column_name].values
         assert not isinstance(values, Categorical)
+
+
+def test_coerce_signed_integer_with_missing_obs_values():
+    """
+    Ensure that columns which should be signed integers are correctly coerced by `ensure_int_columns_are_ints`
+    """
+
+    data = pd.DataFrame({"New Dimension": ["A", "B", "C"], "Value": [1, None, -3]})
+
+    cube = Cube(
+        CatalogMetadata("Some Dataset"),
+        data,
+        [
+            QbColumn(
+                "New Dimension",
+                NewQbDimension.from_data("Some Dimension", data["New Dimension"]),
+            ),
+            QbColumn(
+                "Value",
+                QbSingleMeasureObservationValue(
+                    NewQbMeasure("Some Measure"),
+                    NewQbUnit("Some Unit"),
+                    data_type="int",
+                ),
+            ),
+        ],
+    )
+
+    ensure_int_columns_are_ints(cube)
+
+    values = cube.data["Value"]
+    assert values.dtype == pd.Int64Dtype(), values.dtype
+    values_set = set(values.values)
+    assert 1 in values_set, "Unsigned value not retained."
+    assert -3 in values_set, "Signed value not retained."
+
+
+def test_coerce_unsigned_integer_with_missing_obs_values():
+    """
+    Ensure that columns which should be signed integers are correctly coerced by `ensure_int_columns_are_ints`
+    """
+
+    data = pd.DataFrame({"New Dimension": ["A", "B", "C"], "Value": [1, None, 3]})
+
+    cube = Cube(
+        CatalogMetadata("Some Dataset"),
+        data,
+        [
+            QbColumn(
+                "New Dimension",
+                NewQbDimension.from_data("Some Dimension", data["New Dimension"]),
+            ),
+            QbColumn(
+                "Value",
+                QbSingleMeasureObservationValue(
+                    NewQbMeasure("Some Measure"),
+                    NewQbUnit("Some Unit"),
+                    data_type="unsignedInt",
+                ),
+            ),
+        ],
+    )
+
+    ensure_int_columns_are_ints(cube)
+
+    values = cube.data["Value"]
+    assert values.dtype == pd.UInt64Dtype(), values.dtype
+    values_set = set(values.values)
+    assert 1 in values_set
+    assert 3 in values_set
+
+
+def test_coerce_attribute_value_with_missing_values():
+    """
+    Ensure that columns which should be signed integers are correctly coerced by `ensure_int_columns_are_ints`
+    """
+
+    data = pd.DataFrame(
+        {"New Dimension": ["A", "B", "C"], "Value": [1, 2, 3], "Error": [11, None, 33]}
+    )
+
+    cube = Cube(
+        CatalogMetadata("Some Dataset"),
+        data,
+        [
+            QbColumn(
+                "New Dimension",
+                NewQbDimension.from_data("Some Dimension", data["New Dimension"]),
+            ),
+            QbColumn(
+                "Value",
+                QbSingleMeasureObservationValue(
+                    NewQbMeasure("Some Measure"),
+                    NewQbUnit("Some Unit"),
+                    data_type="unsignedInt",
+                ),
+            ),
+            QbColumn("Error", NewQbAttributeLiteral(data_type="int", label="Error")),
+        ],
+    )
+
+    ensure_int_columns_are_ints(cube)
+
+    error_values = cube.data["Error"]
+    assert error_values.dtype == pd.Int64Dtype(), error_values.dtype
+    error_values_set = set(error_values.values)
+    assert 11 in error_values_set
+    assert 33 in error_values_set
 
 
 if __name__ == "__main__":

--- a/csvcubed/tests/unit/writers/test_qbwriter.py
+++ b/csvcubed/tests/unit/writers/test_qbwriter.py
@@ -1,9 +1,13 @@
-import pytest
+from tempfile import TemporaryDirectory
+from typing import List
 from copy import deepcopy
+import csv
+from pathlib import Path
+
+import pytest
 import pandas as pd
 from rdflib import RDFS, Graph, URIRef, Literal
 from csvcubedmodels import rdf
-from typing import List
 
 from csvcubed.models.cube import *
 from csvcubed.models.cube import (
@@ -1309,6 +1313,52 @@ def test_qb_order_of_components():
         rdf.QB.order,
         Literal(4),
     ) in graph
+
+
+def test_output_integer_obs_val_with_missing_values():
+    """
+    Due to the way that pandas represents missing values (as NaN), instead of interpreting an integer data column as
+     integers, it represents the column as decimal values when some values are missing. Therefore we need to explicitly
+     coerce these values back to integers.
+
+     This test ensures that we can write CSVs to disk which contain integer values even when one of the obs_vals is
+     missing.
+    """
+
+    data = pd.DataFrame({"New Dimension": ["A", "B", "C"], "Value": [1, None, 3]})
+
+    cube = Cube(
+        CatalogMetadata("Some Dataset"),
+        data,
+        [
+            QbColumn(
+                "New Dimension",
+                NewQbDimension.from_data("Some Dimension", data["New Dimension"]),
+            ),
+            QbColumn(
+                "Value",
+                QbSingleMeasureObservationValue(
+                    NewQbMeasure("Some Measure"),
+                    NewQbUnit("Some Unit"),
+                    data_type="int",
+                ),
+            ),
+        ],
+    )
+
+    qb_writer = QbWriter(cube)
+    with TemporaryDirectory() as temp_dir:
+        temp_dir = Path(temp_dir)
+        qb_writer.write(temp_dir)
+        with open(temp_dir / "some-dataset.csv") as csv_file:
+            rows = list(csv.reader(csv_file, delimiter=",", quotechar='"'))
+            for row in rows[1:]:
+                value: str = row[1]
+                if len(value) > 0:
+                    # If any of the values are not integers (e.g. "1.0") the next line will throw an exception.
+                    int_val = int(value)
+                    assert isinstance(int_val, int)
+                # else: len == 0 implies it's a missing value, which is expected in one location.
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When the observation values in a dataset are marked as integers, but a value is missing, pandas unhelpfully represents all of the interger values as decimals/floats/doubles. This means that the CSV-Ws we generate are invalid since they claim that the contents of the obs val column is an integer, but the values are actually decimals.

This PR addresses this bug and ensures that the datatype is correctly serialised to disk.  

Addressed Issue #360