### PR TITLE
Charles rendle/issue229 Bug Reporting - User Guidance

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/bug-report.yml
@@ -11,15 +11,6 @@ body:
       issue, please ensure you have read [our bug reporting guidelines](https://gss-cogs.github.io/csvcubed-docs/external/guides/raise-issue/#report-bugs) 
       as well as checking the open issues for existing issues regarding your bug.
 
-- type: checkboxes
-    id: checks
-    attributes:
-      label: "Guidance and existing issues check"
-      options:
-        - label: >
-            I have read the guidelines and checked that this issue has not already been reported.
-          required: true
-
 - type: textarea
   attributes: 
     label: "Describe the issue:"
@@ -68,4 +59,3 @@ body:
       Please state to which version of csvcubed this issue relates and on which operating system it has occured.
   validations:
     required: true
-    

--- a/.github/workflows/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/bug-report.yml
@@ -8,7 +8,7 @@ body:
   attributes:
     value: >
       Thank you for taking the time to file a bug report. Before creating a new 
-      issue, please ensure you have read [our bug reporting guidelines](https://gss-cogs.github.io/csvcubed-docs/external/guides/raise-issue/) 
+      issue, please ensure you have read [our bug reporting guidelines](https://gss-cogs.github.io/csvcubed-docs/external/guides/raise-issue/#report-bugs) 
       as well as checking the open issues for existing issues regarding your bug.
 
 - type: checkboxes
@@ -41,7 +41,7 @@ body:
     label: "Error message obtained / Resulting behaviour:"
     description: >
       Include the full error message, if any. Detailed error logging can 
-      be obtained by following [this guide]().
+      be obtained by following [this guide](https://gss-cogs.github.io/csvcubed-docs/external/guides/raise-issue/#obtaining-error-logs).
   validations:
     required: true
 
@@ -68,3 +68,4 @@ body:
       Please state to which version of csvcubed this issue relates and on which operating system it has occured.
   validations:
     required: true
+    

--- a/.github/workflows/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,70 @@
+name: Bug Report
+description: Report incorrect behaviour in the csvcubed library
+title: [BUG]:
+labels: [Bug]
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      Thank you for taking the time to file a bug report. Before creating a new 
+      issue, please ensure you have read [our bug reporting guidelines](https://gss-cogs.github.io/csvcubed-docs/external/guides/raise-issue/) 
+      as well as checking the open issues for existing issues regarding your bug.
+
+- type: checkboxes
+    id: checks
+    attributes:
+      label: "Guidance and existing issues check"
+      options:
+        - label: >
+            I have read the guidelines and checked that this issue has not already been reported.
+          required: true
+
+- type: textarea
+  attributes: 
+    label: "Describe the issue:"
+    description: >
+      Please briefly describe the issue.
+  validations:
+    required: true
+
+- type: textarea
+  attributes: 
+    label: "Reproducible steps / Code example:"
+    description: >
+      Please provide a minimal, self-contained and reproducible example or example steps which demonstrates the issue.
+  validations:
+    required: true
+
+- type: textarea
+  attributes: 
+    label: "Error message obtained / Resulting behaviour:"
+    description: >
+      Include the full error message, if any. Detailed error logging can 
+      be obtained by following [this guide]().
+  validations:
+    required: true
+
+- type: textarea
+  attributes: 
+    label: "Expected behaviour:"
+    description: >
+      Describe the expected outcome of the issue causing action.
+  validations:
+    required: true
+
+- type: textarea
+  attributes: 
+    label: "Additional Information:"
+    description: >
+      Please feel free to add any additional information which may be useful to diagnose the issue.
+  validations:
+    required: false
+
+- type: textarea
+  attributes: 
+    label: "Version information + Operating System:"
+    description: >
+      Please state to which version of csvcubed this issue relates and on which operating system it has occured.
+  validations:
+    required: true

--- a/external-docs/docs/guides/raise-issue.md
+++ b/external-docs/docs/guides/raise-issue.md
@@ -4,8 +4,6 @@ TODO:
 
 * How to obtain detailed error log
 
-* How to email sensitive bug reports
-
 * How to get support from the IDP-D team
 
 
@@ -21,12 +19,12 @@ Well written bug reports are very helpful. See this [stackoverflow article](http
     2. Reproducible steps / Code example
     3. Error message obtained / Resulting behaviour
     4. Expected behaviour
-    5. Any Additional Information
-    6. Version information + Operating System
+    5. Any additional information
+    6. Version information + Operating system
 
 To obtain detailed error logging ...
 
-In the event that your bug can only be reproduced using sensitive information ...
+In the event that your issue can only be reproduced using sensitive information, please send your report to csvcubed@gsscogs.uk and try to follow the template detailed above as closely as possible.
 
 
 

--- a/external-docs/docs/guides/raise-issue.md
+++ b/external-docs/docs/guides/raise-issue.md
@@ -1,12 +1,5 @@
 # Raise an issue
 
-TODO: 
-
-* How to obtain detailed error log
-
-* How to get support from the IDP-D team
-
-
 ## Report Bugs
 
 If you find a bug in the code, please do not hesitate to submit a ticket to the issue tracker.
@@ -22,9 +15,14 @@ Well written bug reports are very helpful. See this [stackoverflow article](http
     5. Any additional information
     6. Version information + Operating system
 
-To obtain detailed error logging ...
+In the event that your issue can only be reproduced using sensitive information, please send your report to [csvcubed@gsscogs.uk](mailto:csvcubed@gsscogs.uk) and try to follow the template detailed above as closely as possible.
 
-In the event that your issue can only be reproduced using sensitive information, please send your report to csvcubed@gsscogs.uk and try to follow the template detailed above as closely as possible.
+## Obtaining Error Logs
+To obtain a detailed error log, please follow the following steps:
 
+1. Set the logging level to debug in the build command. `build --log-level debug`
+2. Rerun the issue causing lines.
+3. Copy and paste the resulting console output into the bug reporting form.
 
-
+**Note:** Logs from the past 7 days are recorded in csvcube's log file `out.log`.
+Feel free to consulte these for more detailed retrospective debugging.

--- a/external-docs/docs/guides/raise-issue.md
+++ b/external-docs/docs/guides/raise-issue.md
@@ -1,3 +1,32 @@
 # Raise an issue
 
-todo: Explain how to raise an issue or file a bug with us. Issue #229.
+TODO: 
+
+* How to obtain detailed error log
+
+* How to email sensitive bug reports
+
+* How to get support from the IDP-D team
+
+
+## Report Bugs
+
+If you find a bug in the code, please do not hesitate to submit a ticket to the issue tracker.
+Well written bug reports are very helpful. See this [stackoverflow article](https://stackoverflow.com/help/minimal-reproducible-example) and this [blog post](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) for tips on writing minimal, reproducible examples. Please also keep in mind the following guidelines when reporting a new bug:
+
+* Check the Errors section of this documentation to see if your issue is addressed.
+* Check the open issues to see if the bug has already been reported. If it has, check the ticket history and comments and feel free to leave additional useful information in comment form.
+* Please format your report using the following template:
+    1. Issue description
+    2. Reproducible steps / Code example
+    3. Error message obtained / Resulting behaviour
+    4. Expected behaviour
+    5. Any Additional Information
+    6. Version information + Operating System
+
+To obtain detailed error logging ...
+
+In the event that your bug can only be reproduced using sensitive information ...
+
+
+


### PR DESCRIPTION
Draft PR as current issue form does not display as intended. At the moment, I am assuming it is a fault in my YAML syntax. 

Currently, PR will add

- Bug reporting documentation page with guidelines and error logging details
- A template for issue reporting forms

I still need to verify that when an issue is submitted, a simple github issue is created. I expect a resulting issue to look something [like this](https://github.com/pandas-dev/pandas/issues/46392) but with the template from `bug-report.yml`.