### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG]:"
+title: "[BUG]"
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]:"
+labels: bug
+assignees: ''
+
+---
+
+Thank you for taking the time to file a bug report. Before creating a new issue, please ensure you have read [our bug reporting guidelines](https://gsscogs.github.io/csvcubeddocs/external/guides/raise-issue/#report-bugs) as well as checking the open issues for existing issues regarding your bug.
+
+**Describe the issue:**
+Please briefly describe the issue.
+
+**Reproducible steps / Code example:**
+Please provide a minimal, self-contained and reproducible example or example steps which demonstrates the issue.
+
+**Error message obtained / Resulting behaviour:**
+Include the full error message, if any. Detailed error logging can be obtained by following [this guide](https://gss-cogs.github.io/csvcubed-docs/external/guides/raise-issue/#obtaining-error-logs).
+
+**Expected behaviour:**
+Describe the expected outcome of the issue causing action.
+
+**Additional Information:**
+Please feel free to add any additional information which may be useful to diagnose the issue.
+
+**Version information + Operating System:**
+Please state to which version of csvcubed this issue relates and on which operating system it has occurred.

--- a/.github/ISSUE_TEMPLATE/request-further-guidance.md
+++ b/.github/ISSUE_TEMPLATE/request-further-guidance.md
@@ -1,13 +1,13 @@
 ---
 name: Request Further Guidance
 about: Request guidance from the team to help with your issue
-title: "[GUIDANCE]: "
+title: "[GUIDANCE] "
 labels: help wanted
 assignees: ''
 
 ---
 
-Thank you for taking the time to seek further support. Before submitting a new ticket, please ensure you have read [our documentation guides](https://gss-cogs.github.io/csvcubed-docs/external/guides/) as well as checking the open issues just in case your problem is bug related.
+Thank you for taking the time to seek further support. Before submitting a new ticket, please ensure you have read [our documentation guides](https://gss-cogs.github.io/csvcubed-docs/external/guides/) as well as checked the open issues, just in case your problem is bug related.
 
 **Describe the issue:**
 Please describe the issue including any error messages you are receiving and steps you have already taken. Detailed error logging can be obtained by following [this guide](https://gss-cogs.github.io/csvcubed-docs/external/guides/raise-issue/#obtaining-error-logs).

--- a/.github/ISSUE_TEMPLATE/request-further-guidance.md
+++ b/.github/ISSUE_TEMPLATE/request-further-guidance.md
@@ -1,0 +1,16 @@
+---
+name: Request Further Guidance
+about: Request guidance from the team to help with your issue
+title: "[GUIDANCE]: "
+labels: help wanted
+assignees: ''
+
+---
+
+Thank you for taking the time to seek further support. Before submitting a new ticket, please ensure you have read [our documentation guides](https://gss-cogs.github.io/csvcubed-docs/external/guides/) as well as checking the open issues just in case your problem is bug related.
+
+**Describe the issue:**
+Please describe the issue including any error messages you are receiving and steps you have already taken. Detailed error logging can be obtained by following [this guide](https://gss-cogs.github.io/csvcubed-docs/external/guides/raise-issue/#obtaining-error-logs).
+
+**Version information + Operating System:**
+Please state to which version of csvcubed this issue relates and on which operating system it has occurred.


### PR DESCRIPTION
Supplementary PR which adds normal markdown issue templates for bug reporting and requesting further guidance from the team. 
Related to Issue229 and [this PR](https://github.com/GSS-Cogs/csvcubed/pull/372)

Had to be added in a separate branch as the github interface for adding issue templates only gives the option to commit to main or open a PR in a new branch.