### PR TITLE
Fixes added to the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.9
 
-RUN apt-get update
-
-# install docker stuff
-RUN apt-get install -y \
+# Installing packages required by docker.
+# To prevent any cache related issues that could occur when building the container and during apt-get install, the apt-get update and apt-get install are added to the same RUN statement 
+# as per the instructions in https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run.
+RUN apt-get update && apt-get install -y \
   apt-transport-https \
   ca-certificates \
   curl \
@@ -15,9 +15,9 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-RUN apt-get update
-
-RUN apt-get install -y docker-ce docker-ce-cli containerd.io
+# To prevent any cache related issues that could occur when building the container and during apt-get install, the apt-get update and apt-get install are added to the same RUN statement 
+# as per the instructions in https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run.
+RUN apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io
 
 RUN python3 -m pip install poetry
 


### PR DESCRIPTION
Since we have `apt-get update` and `apt-get install` in separate `RUN` statements inside the Dockerfile, the latter command was failing when building the container (without cache).

Docker best practices recommend combining the two commands into a single `RUN` statement since "Using apt-get update alone in a RUN statement causes caching issues and subsequent apt-get install instructions fail." This PR contains this update.

See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run for reference. 