### PR TITLE
quickstart minor changes made

### DIFF
--- a/external-docs/docs/quick-start/describing-csv.md
+++ b/external-docs/docs/quick-start/describing-csv.md
@@ -20,7 +20,7 @@ This is what a basic [`qube-config.json`](../guides/qube-config.md) looks like:
     "description": "Sweden has been competing in Eurovision since 1958, with an enviable track record of wins. This dataset covers all contests since 1958, their artists, the song names, language (if mono-lingual), and some observations covering points in final, rank in final, and number of artists on stage. Data originally sourced from https://en.wikipedia.org/w/index.php?title=Sweden_in_the_Eurovision_Song_Contest&oldid=1081060799",
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "publisher": "https://www.ons.gov.uk",
-    "dataset_issued": "2022-04-08",
+    "dataset_issued": "2022-04-08T00:00:00Z",
     "keywords": [
         "Eurovision",
         "Song Contest",

--- a/external-docs/docs/quick-start/designing-csv.md
+++ b/external-docs/docs/quick-start/designing-csv.md
@@ -18,7 +18,7 @@ The [standard shape](../guides/shape-data.md#standard-shape) of data is the reco
 
 In the above table:
 
-* *identifying characteristics* are one or more columns which identify the sub-set of the population has been observed in a given row. This are called [dimensions](../glossary/index.md#dimensionhttpswwww3orgtrvocab-data-cubecubes-model) elsewhere in documentation.
+* *identifying characteristics* are one or more columns which identify the sub-set of the population that has been observed in a given row. These are called [dimensions](../glossary/index.md#dimensionhttpswwww3orgtrvocab-data-cubecubes-model) elsewhere in documentation.
 * the `Value` column contains the value which has been observed or measured; there is only ever one observed value per row in the [standard shape](../guides/shape-data.md#standard-shape).
 * the `Measure` column describes what has been observed or measured; note that the measure should not include any information about the units of measure.
 * the `Unit` column describes the unit of measure in which the `Value` has been recorded.

--- a/external-docs/docs/quick-start/inspect.md
+++ b/external-docs/docs/quick-start/inspect.md
@@ -5,7 +5,7 @@ This page is designed to help you inspect an existing CSV-W. It assumes that you
 To inspect the `sweden-at-eurovision-no-missing.csv-metadata.json` data cube we built in [Building a CSV-W](build.md), we run the [csvcubed inspect](../guides/command-line/inspect-command.md) command:
 
 ```bash
-csvcubed inspect sweden_at_eurovision_no_missing.csv-metadata.json
+csvcubed inspect sweden-at-eurovision-no-missing.csv-metadata.json
 ```
 
 All being well we get the below output. A detailed explanation of this output is provided in [csvcubed inspect](../guides/command-line/inspect-command.md#output-format) section.


### PR DESCRIPTION
After working through the quick start guide, there are a few very minor changes which need to be made.
<br>
- > identifying characteristics are one or more columns which identify the sub-set of the population has been observed in a given row. This are called [dimensions](https://gss-cogs.github.io/csvcubed-docs/external/glossary/#dimensionhttpswwww3orgtrvocab-data-cubecubes-model) elsewhere in documentation.

Very simple proposed changed to add a `that` into the first sentence and change `This` to `These` at the start of the second.
<br>

- > {
    "$schema": "https://purl.org/csv-cubed/qube-config/v1.0",
    "title": "Sweden at Eurovision",
    "summary": "List of Swedish entries to the Eurovision Song Contest since 1958.",
    "description": "Sweden has been competing in Eurovision since 1958, with an enviable track record of wins. This dataset covers all contests since 1958, their artists, the song names, language (if mono-lingual), and some observations covering points in final, rank in final, and number of artists on stage. Data originally sourced from https://en.wikipedia.org/w/index.php?title=Sweden_in_the_Eurovision_Song_Contest&oldid=1081060799",
    "license": "https://creativecommons.org/licenses/by/4.0/",
    "publisher": "https://www.ons.gov.uk",
    "dataset_issued": "2022-04-08",
    "keywords": [
        "Eurovision",
        "Song Contest",
        "Sweden",
        "European Broadcasting Union"
    ]
}

Using this as the exact `qube-config.json` file results in an error during build (build.py:52) 
`2022-04-19 14:25:09,278 - csvcubed.cli.build - ERROR - Validation Error: metadata, dataset_issued - invalid datetime format (build.py:52)`

Proposed changing the `dataset_issued` filed to `"2022-04-08T00:00:00Z"`
<br>

- > `csvcubed inspect sweden_at_eurovision_no_missing.csv-metadata.json`

Filename does not include underscores, should be dashes instead.
`csvcubed inspect sweden-at-eurovision-no-missing.csv-metadata.json`
