### PR TITLE
Issue 459/native compiled csv2rdf

### DIFF
--- a/csvcubed-devtools/csvcubeddevtools/behaviour/csv2rdf.py
+++ b/csvcubed-devtools/csvcubeddevtools/behaviour/csv2rdf.py
@@ -18,6 +18,7 @@ from csvcubeddevtools.behaviour.temporarydirectory import get_context_temp_dir_p
 client = docker.from_env()
 client.images.pull("gsscogs/csv2rdf")
 
+
 def _run_csv2rdf(context, metadata_file_path: Path) -> Tuple[int, str, Optional[str]]:
     with TemporaryDirectory() as tmp_dir:
         tmp_dir = Path(tmp_dir)

--- a/csvcubed-devtools/csvcubeddevtools/behaviour/csv2rdf.py
+++ b/csvcubed-devtools/csvcubeddevtools/behaviour/csv2rdf.py
@@ -16,7 +16,7 @@ from csvcubeddevtools.helpers.tar import dir_to_tar, extract_tar
 from csvcubeddevtools.behaviour.temporarydirectory import get_context_temp_dir_path
 
 client = docker.from_env()
-client.images.pull("gsscogs/csv2rdf")
+client.images.pull("gsscogs/csv2rdf:native")
 
 
 def _run_csv2rdf(context, metadata_file_path: Path) -> Tuple[int, str, Optional[str]]:

--- a/csvcubed-devtools/csvcubeddevtools/behaviour/csv2rdf.py
+++ b/csvcubed-devtools/csvcubeddevtools/behaviour/csv2rdf.py
@@ -18,14 +18,17 @@ from csvcubeddevtools.behaviour.temporarydirectory import get_context_temp_dir_p
 client = docker.from_env()
 client.images.pull("gsscogs/csv2rdf")
 
+client.containers
 
 def _run_csv2rdf(context, metadata_file_path: Path) -> Tuple[int, str, Optional[str]]:
     with TemporaryDirectory() as tmp_dir:
         tmp_dir = Path(tmp_dir)
+        
         csv2rdf = client.containers.create(
-            "gsscogs/csv2rdf",
+            "gsscogs/csv2rdf:native",
             command=f"csv2rdf -u /tmp/{metadata_file_path.name} -o /tmp/csv2rdf.ttl -m annotated",
         )
+
         csv2rdf.put_archive("/tmp", dir_to_tar(metadata_file_path.parent))
 
         csv2rdf.start()

--- a/csvcubed-devtools/csvcubeddevtools/behaviour/csv2rdf.py
+++ b/csvcubed-devtools/csvcubeddevtools/behaviour/csv2rdf.py
@@ -18,17 +18,13 @@ from csvcubeddevtools.behaviour.temporarydirectory import get_context_temp_dir_p
 client = docker.from_env()
 client.images.pull("gsscogs/csv2rdf")
 
-client.containers
-
 def _run_csv2rdf(context, metadata_file_path: Path) -> Tuple[int, str, Optional[str]]:
     with TemporaryDirectory() as tmp_dir:
         tmp_dir = Path(tmp_dir)
-        
         csv2rdf = client.containers.create(
             "gsscogs/csv2rdf:native",
             command=f"csv2rdf -u /tmp/{metadata_file_path.name} -o /tmp/csv2rdf.ttl -m annotated",
         )
-
         csv2rdf.put_archive("/tmp", dir_to_tar(metadata_file_path.parent))
 
         csv2rdf.start()


### PR DESCRIPTION
## What is is?

Switch to using a native/compiled version of csv2rdf for tests.

This makes use of: https://github.com/GSS-Cogs/csv2rdf-docker/tree/native which Alex put together a few weeks ago.

Have pushed as `gsscogs/csv2rdf:native` _for now_ .... you _could_ merge Alexs branch into master but I'm a little wary until we've run on it for a while (I'm imaging updating `csv2rdf:latest` before a release but not until then.... see if the wheels fall off in the meantime). Happy to take a steer on that though.

Runs as expected under both csvcubed and gss-utils.

## Speed Difference

While running `behave ./test/behaviours` against the `csvcubed` module (average across three runs):
`csv2rdf:native`: 3m
`csv2rdf:latest`: 8m

The tests on Jenkins give every appearence of speeding up but there's so many factors I don't even want to try putting numbers on it, but they run and it certainly won't be slower given the above.

## How to review

Sanity check tests run as expected for you and with a demonstrable speed increase.