### PR TITLE
Correcting date time code list serialisation

### DIFF
--- a/csvcubed/csvcubed/models/cube/qb/components/concept.py
+++ b/csvcubed/csvcubed/models/cube/qb/components/concept.py
@@ -47,7 +47,7 @@ class ExistingQbConcept(SecondaryQbStructuralDefinition):
     _existing_concept_uri_validator = validate_uri("existing_concept_uri")
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class DuplicatedQbConcept(NewQbConcept, ExistingQbConcept):
     """
     Represents a QbConcept which duplicates an :class:`ExistingQbConcept` with overriding label, notation, etc.

--- a/csvcubed/csvcubed/readers/preconfiguredtemplates.py
+++ b/csvcubed/csvcubed/readers/preconfiguredtemplates.py
@@ -74,8 +74,8 @@ def apply_preconfigured_values_from_template(
     column_config: Dict[str, Any], version_module_path: str, column_name: str
 ) -> None:
     """
-    Preset templates are found through template lookup file. Propeties are then taken from templates and
-    added to column config, with user specified propeties overriding template propeties.
+    Preset templates are found through template lookup file. Properties are then taken from templates and
+    added to column config, with user specified properties overriding template properties.
     """
     # if column_config doesn't have the `from_template` property, just terminate the function now
     if "from_template" not in column_config:

--- a/csvcubed/csvcubed/readers/preconfiguredtemplates.py
+++ b/csvcubed/csvcubed/readers/preconfiguredtemplates.py
@@ -10,6 +10,7 @@ from typing import Dict, Any
 from requests.exceptions import JSONDecodeError, HTTPError
 
 from csvcubed.utils.cache import session
+from csvcubed.utils.uri import csvw_column_name_safe
 
 TEMPLATE_BASE_URL = "https://raw.githubusercontent.com/GSS-Cogs/csvcubed/main/csvcubed/csvcubed/readers/cubeconfig/{}/templates/{}"
 
@@ -102,6 +103,6 @@ def apply_preconfigured_values_from_template(
             if isinstance(fetch_template[template_property], str):
                 column_config[template_property] = fetch_template[
                     template_property
-                ].replace("<column_name>", column_name)
+                ].replace("<column_name>", csvw_column_name_safe(column_name))
             else:
                 column_config[template_property] = fetch_template[template_property]


### PR DESCRIPTION
The PR addresses a couple of bugs:

1. `<column_name>` substitution in column templates was generating invalid URI templates which didn't correctly reference the column.


2. The code which generated local date-time code lists was using the wrong property to make the decision. No testing existed to validate this.
 
Addresses issue #477 