### PR TITLE
update licence documentation

### DIFF
--- a/external-docs/docs/guides/linked-data/licenses.md
+++ b/external-docs/docs/guides/linked-data/licenses.md
@@ -12,8 +12,11 @@ Licensing your data is an important part of publishing open data. Setting the li
 | [Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)](https://creativecommons.org/licenses/by-nc/4.0/) | <https://creativecommons.org/licenses/by-nc/4.0/> |
 | [Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)](https://creativecommons.org/licenses/by-nc-sa/4.0/) | <https://creativecommons.org/licenses/by-nc-sa/4.0/> |
 | [Attribution-NonCommercial-NoDerivative 4.0 International (CC BY-NC-ND 4.0)](https://creativecommons.org/licenses/by-nc-nd/4.0/) | <https://creativecommons.org/licenses/by-nc-nd/4.0/> |
+| [Creative Commons Public Domain (CC0)](http://creativecommons.org/publicdomain/zero/1.0/) | <http://creativecommons.org/publicdomain/zero/1.0/> |
+| [Digital Public Space Licence, version 1.0](http://bbcarchdev.github.io/licences/dps/1.0#id) | <http://bbcarchdev.github.io/licences/dps/1.0#id> |
 | [European Union Public Licence v1.1](https://spdx.org/licenses/EUPL-1.1.html)  |  <https://spdx.org/licenses/EUPL-1.1.html>  |
 | [European Union Public Licence v1.2](https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12)  |  <https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12> |
 | [Open Data Commons Public Domain Dedication and License (PDDL) v1.0](http://www.opendatacommons.org/licenses/pddl/1.0/) | <http://www.opendatacommons.org/licenses/pddl/1.0/> |
 | [Open Government License v3](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) | <http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/>                                |
-| [MIT](https://opensource.org/licenses/mit-license.php)                                                  | <https://opensource.org/licenses/mit-license.php>           
+| [MIT](https://opensource.org/licenses/mit-license.php)                                                  | <https://opensource.org/licenses/mit-license.php>           |
+| [No License](https://choosealicense.com/no-permission/) | <https://choosealicense.com/no-permission/> |

--- a/external-docs/docs/guides/linked-data/licenses.md
+++ b/external-docs/docs/guides/linked-data/licenses.md
@@ -6,5 +6,14 @@ Licensing your data is an important part of publishing open data. Setting the li
 
 | License                                                                                                 | URI (use this in your [qube-config.json metadata configuration](../configuration/qube-config.md#metadata)) |
 |:--------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------|
+| [Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/) | <https://creativecommons.org/licenses/by/4.0/> |
+| [Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/) | <https://creativecommons.org/licenses/by-sa/4.0/> |
+| [Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)](https://creativecommons.org/licenses/by-nd/4.0/) | <https://creativecommons.org/licenses/by-nd/4.0/> |
+| [Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)](https://creativecommons.org/licenses/by-nc/4.0/) | <https://creativecommons.org/licenses/by-nc/4.0/> |
+| [Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)](https://creativecommons.org/licenses/by-nc-sa/4.0/) | <https://creativecommons.org/licenses/by-nc-sa/4.0/> |
+| [Attribution-NonCommercial-NoDerivative 4.0 International (CC BY-NC-ND 4.0)](https://creativecommons.org/licenses/by-nc-nd/4.0/) | <https://creativecommons.org/licenses/by-nc-nd/4.0/> |
+| [European Union Public Licence v1.1](https://spdx.org/licenses/EUPL-1.1.html)  |  <https://spdx.org/licenses/EUPL-1.1.html>  |
+| [European Union Public Licence v1.2](https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12)  |  <https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12> |
+| [Open Data Commons Public Domain Dedication and License (PDDL) v1.0](http://www.opendatacommons.org/licenses/pddl/1.0/) | <http://www.opendatacommons.org/licenses/pddl/1.0/> |
 | [Open Government License v3](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) | <http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/>                                |
-| [MIT](https://opensource.org/licenses/mit-license.php)                                                  | <https://opensource.org/licenses/mit-license.php>                                                          |
+| [MIT](https://opensource.org/licenses/mit-license.php)                                                  | <https://opensource.org/licenses/mit-license.php>           


### PR DESCRIPTION
supports PR: https://github.com/GSS-Cogs/GDP-vocabs/pull/13

I've only documented the V4 Creative Commons licenses, as there are strong recommendations not to use the earlier licences for data (as they don't cover data in databases). So while we support them I thought it was best to to advertise it. 