### PR TITLE
Reverted const to default in schema

### DIFF
--- a/csvcubed/csvcubed/schema/codelist-config/v1_0/codelistconfig-example.jsonc
+++ b/csvcubed/csvcubed/schema/codelist-config/v1_0/codelistconfig-example.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "file:///workspaces/csvcubed/csvcubed/csvcubed/schema/codelist-config/v1_0/schema.json",
+  "$schema": "https://purl.org/csv-cubed/code-list-config/v1.0",
   "title": "Title of the code list",
   "description": "Description of the code list",
   "summary": "Summary of the code list.",
@@ -16,7 +16,7 @@
     "keyword2"
   ],
   "sort": {
-    "by": "labels",
+    "by": "label",
     "method": "ascending"
   },
   "concepts": [

--- a/csvcubed/csvcubed/schema/codelist-config/v1_0/schema.json
+++ b/csvcubed/csvcubed/schema/codelist-config/v1_0/schema.json
@@ -8,7 +8,7 @@
   "properties": {
     "$schema": {
       "type": "string",
-      "const": "https://purl.org/csv-cubed/code-list-config/v1.0"
+      "default": "https://purl.org/csv-cubed/code-list-config/v1.0"
     },
     "id": {
       "description": "A unique id for the code list.",

--- a/csvcubed/csvcubed/schema/cube-config/v1_0/schema.json
+++ b/csvcubed/csvcubed/schema/cube-config/v1_0/schema.json
@@ -8,7 +8,7 @@
     "properties": {
         "$schema": {
             "type": "string",
-            "const": "https://purl.org/csv-cubed/qube-config/v1.0"
+            "default": "https://purl.org/csv-cubed/qube-config/v1.0"
         },
         "id": {"description": "A unique id for the cube", "type": "string"},
         "title": {"description": "A title for this data set", "type": "string"},

--- a/csvcubed/csvcubed/schema/cube-config/v1_1/qbconfig-example.jsonc
+++ b/csvcubed/csvcubed/schema/cube-config/v1_1/qbconfig-example.jsonc
@@ -1,6 +1,6 @@
 {
     // The ability to define curies in qbconfig.jsonc
-    "$schema": "https://raw.githubusercontent.com/GSS-Cogs/csvcubed/294-define-codelist-in-qubeconfig/csvcubed/csvcubed/schema/cube-config/v1_1/schema.json",
+    "$schema": "https://purl.org/csv-cubed/qube-config/v1.1",
     "title": "Some Qube",
     "description": "A string of any length or markdown, etc",
     "summary": "A string of any length or markdown, etc",

--- a/csvcubed/csvcubed/schema/cube-config/v1_1/schema.json
+++ b/csvcubed/csvcubed/schema/cube-config/v1_1/schema.json
@@ -10,7 +10,7 @@
     "properties": {
         "$schema": {
             "type": "string",
-            "const": "https://purl.org/csv-cubed/qube-config/v1.1"
+            "default": "https://purl.org/csv-cubed/qube-config/v1.1"
         },
         "id": {
             "description": "A unique id for the cube",


### PR DESCRIPTION
This PR contains changes to the code list and cube config schemas so that the default is used instead of const.