### PR TITLE
Issue 614 - prov-o csvcubed version number is harded coded in behaviour tests

### DIFF
--- a/tests/behaviour/qbwriter.feature
+++ b/tests/behaviour/qbwriter.feature
@@ -629,7 +629,7 @@ Feature: Test outputting CSV-Ws with Qb flavouring.
     <file:/tmp/cube-data-convention-ok.csv#measure/cost-of-living-index> <http://www.w3.org/2000/01/rdf-schema#label> "Cost of living index"@en;
       <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#decimal> .
     """
-
+  @wip
   Scenario: A QbCube should generate csvcubed version specific rdf
     Given a single-measure QbCube with identifier "qb-id-10002" named "Some Qube"
     When the cube is serialised to CSV-W
@@ -637,13 +637,12 @@ Feature: Test outputting CSV-Ws with Qb flavouring.
     And the file at "qb-id-10002.csv-metadata.json" should exist
     And csvlint validation of all CSV-Ws should succeed
     And csv2rdf on all CSV-Ws should succeed
-    And the RDF should contain
-      """
-      @prefix prov: <http://www.w3.org/ns/prov#> .
+    And the RDF should contain version specific triples
+    """
+    @prefix prov: <http://www.w3.org/ns/prov#> .
 
-      <file:/tmp/a-code-list.csv#code-list> a prov:Entity ;
-        prov:wasGeneratedBy <file:/tmp/a-code-list.csv#csvcubed-build-activity> .
+    <file:/tmp/a-code-list.csv#code-list> a prov:Entity ;
+      prov:wasGeneratedBy <file:/tmp/a-code-list.csv#csvcubed-build-activity> .
 
-      <file:/tmp/qb-id-10002.csv#csvcubed-build-activity> a prov:Activity ;
-        prov:used <https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0> .
-      """
+    <file:/tmp/qb-id-10002.csv#csvcubed-build-activity> a prov:Activity;
+    """

--- a/tests/behaviour/qbwriter.feature
+++ b/tests/behaviour/qbwriter.feature
@@ -629,7 +629,7 @@ Feature: Test outputting CSV-Ws with Qb flavouring.
     <file:/tmp/cube-data-convention-ok.csv#measure/cost-of-living-index> <http://www.w3.org/2000/01/rdf-schema#label> "Cost of living index"@en;
       <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#decimal> .
     """
-  @wip
+    
   Scenario: A QbCube should generate csvcubed version specific rdf
     Given a single-measure QbCube with identifier "qb-id-10002" named "Some Qube"
     When the cube is serialised to CSV-W

--- a/tests/behaviour/skoscodelists.feature
+++ b/tests/behaviour/skoscodelists.feature
@@ -1,5 +1,5 @@
 Feature: Test outputting CSV-Ws containing `SKOS:ConceptScheme`s.
-  @wip
+
   Scenario: A basic code list can be serialised to a valid CSV-W described in SKOS containing csvcubed version specific rdf.
     Given a NewQbCodeList named "Basic Code-list"
     When the code list is serialised to CSV-W

--- a/tests/behaviour/skoscodelists.feature
+++ b/tests/behaviour/skoscodelists.feature
@@ -1,5 +1,5 @@
 Feature: Test outputting CSV-Ws containing `SKOS:ConceptScheme`s.
-
+  @wip
   Scenario: A basic code list can be serialised to a valid CSV-W described in SKOS containing csvcubed version specific rdf.
     Given a NewQbCodeList named "Basic Code-list"
     When the code list is serialised to CSV-W
@@ -43,12 +43,19 @@ Feature: Test outputting CSV-Ws containing `SKOS:ConceptScheme`s.
 
       @prefix prov: <http://www.w3.org/ns/prov#> .
 
-      basicCodeList:code-list a prov:Entity;
-      prov:wasGeneratedBy basicCodeList:csvcubed-build-activity.
+      basicCodeList:code-list a prov:Entity ;
+        prov:wasGeneratedBy basicCodeList:csvcubed-build-activity.
 
-      basicCodeList:csvcubed-build-activity a prov:Activity;
-      prov:used <https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0>.
+      basicCodeList:csvcubed-build-activity a prov:Activity.
+
       """
+    And the RDF should contain version specific triples
+    """
+      @prefix basicCodeList: <file:/tmp/basic-code-list.csv#>.
+      @prefix prov: <http://www.w3.org/ns/prov#> .
+        
+      basicCodeList:csvcubed-build-activity a prov:Activity;
+    """
 
   Scenario: A code list with duplicate notations fails validation.
     Given a NewQbCodeList named "Contains Duplicates" containing duplicates

--- a/tests/behaviour/steps/qbwriter.py
+++ b/tests/behaviour/steps/qbwriter.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from behave import Given, When, Then, Step
 from csvcubeddevtools.behaviour.file import get_context_temp_dir_path
 from csvcubeddevtools.helpers.file import get_test_cases_dir
+from csvcubeddevtools.behaviour.rdf import test_graph_diff
 from rdflib import Graph
 
 from csvcubed.models.cube import *
@@ -24,6 +25,7 @@ from csvcubed.readers.skoscodelistreader import extract_code_list_concept_scheme
 from csvcubed.writers.qbwriter import QbWriter
 from csvcubed.utils.qb.validation.cube import validate_qb_component_constraints
 from csvcubed.utils.pandas import read_csv
+from csvcubed.utils.version import get_csvcubed_version_uri
 
 _test_case_dir = get_test_cases_dir()
 
@@ -88,9 +90,7 @@ def step_impl(context, cube_name: str):
         ),
         QbColumn(
             "Value",
-            QbObservationValue(
-                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
-            ),
+            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
         ),
     ]
 
@@ -124,9 +124,7 @@ def step_impl(context, cube_name: str):
         ),
         QbColumn(
             "Value",
-            QbObservationValue(
-                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
-            ),
+            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
         ),
     ]
 
@@ -149,9 +147,7 @@ def step_impl(context, cube_name: str, csvw_file_path: str):
         ),
         QbColumn(
             "Value",
-            QbObservationValue(
-                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
-            ),
+            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
         ),
     ]
 
@@ -180,9 +176,7 @@ def _get_single_measure_cube_with_name_and_id(
         QbColumn("D", NewQbDimension.from_data("D code list", _standard_data["D"])),
         QbColumn(
             "Value",
-            QbObservationValue(
-                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
-            ),
+            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
         ),
     ]
 
@@ -209,9 +203,7 @@ def step_impl(context, cube_name: str):
         ),
         QbColumn(
             "Value",
-            QbObservationValue(
-                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
-            ),
+            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
         ),
     ]
 
@@ -227,9 +219,7 @@ def step_impl(context, cube_name: str):
         QbColumn("A", NewQbDimension.from_data("A Dimension", data["A"])),
         QbColumn(
             "Value",
-            QbObservationValue(
-                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
-            ),
+            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
         ),
     ]
 
@@ -256,9 +246,7 @@ def step_impl(context, cube_name: str):
         QbColumn("D", NewQbDimension.from_data("D code list", _standard_data["D"])),
         QbColumn(
             "Value",
-            QbObservationValue(
-                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
-            ),
+            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
         ),
     ]
 
@@ -289,9 +277,7 @@ def step_impl(context, cube_name: str):
         ),
         QbColumn(
             "Value",
-            QbObservationValue(
-                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
-            ),
+            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
         ),
     ]
 
@@ -371,9 +357,7 @@ def step_impl(context, cube_name: str):
         ),
         QbColumn(
             "Value",
-            QbObservationValue(
-                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
-            ),
+            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
         ),
     ]
 
@@ -429,7 +413,7 @@ def step_impl(context, file: str):
 def step_impl(context):
     writer = QbWriter(context.cube)
     temp_dir = get_context_temp_dir_path(context)
-    
+
     writer.write(temp_dir)
     context.csv_file_name = writer.csv_file_name
 
@@ -481,9 +465,7 @@ def step_impl(context, cube_name: str, type: str, data_type: str):
     dim = QbColumn("A", NewQbDimension.from_data("A Dimension", data["A"]))
     val = QbColumn(
         "Value",
-        QbObservationValue(
-            NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
-        ),
+        QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
     )
     if data_type == "int":
         if type == "new":
@@ -567,9 +549,7 @@ def step_impl(context, cube_name: str):
         ),
         QbColumn(
             "Observed Value",
-            QbObservationValue(
-                NewQbMeasure("Part-time"), NewQbUnit("Num of Students")
-            ),
+            QbObservationValue(NewQbMeasure("Part-time"), NewQbUnit("Num of Students")),
         ),
     ]
 
@@ -891,3 +871,13 @@ def assert_uri_style_for_uri(uri_style: URIStyle, uri: str, node):
         assert path.endswith(".csv") or path.endswith(
             ".json"
         ), f"expected {node} to end with .csv or .json"
+
+@then(u'the RDF should contain version specific triples')
+def step_impl(context):
+
+    context.version_triples = context.text + "\n" + f"prov:used <{get_csvcubed_version_uri()}> ."
+
+    test_graph_diff(
+        Graph().parse(format="turtle", data=context.turtle),
+        Graph().parse(format="turtle", data=context.version_triples.strip()),
+    )

--- a/tests/behaviour/steps/qbwriter.py
+++ b/tests/behaviour/steps/qbwriter.py
@@ -90,7 +90,9 @@ def step_impl(context, cube_name: str):
         ),
         QbColumn(
             "Value",
-            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
+            QbObservationValue(
+                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
+            ),
         ),
     ]
 
@@ -124,7 +126,9 @@ def step_impl(context, cube_name: str):
         ),
         QbColumn(
             "Value",
-            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
+            QbObservationValue(
+                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
+            ),
         ),
     ]
 
@@ -147,7 +151,9 @@ def step_impl(context, cube_name: str, csvw_file_path: str):
         ),
         QbColumn(
             "Value",
-            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
+            QbObservationValue(
+                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
+            ),
         ),
     ]
 
@@ -176,7 +182,9 @@ def _get_single_measure_cube_with_name_and_id(
         QbColumn("D", NewQbDimension.from_data("D code list", _standard_data["D"])),
         QbColumn(
             "Value",
-            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
+            QbObservationValue(
+                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
+            ),
         ),
     ]
 
@@ -203,7 +211,9 @@ def step_impl(context, cube_name: str):
         ),
         QbColumn(
             "Value",
-            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
+            QbObservationValue(
+                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
+            ),
         ),
     ]
 
@@ -219,7 +229,9 @@ def step_impl(context, cube_name: str):
         QbColumn("A", NewQbDimension.from_data("A Dimension", data["A"])),
         QbColumn(
             "Value",
-            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
+            QbObservationValue(
+                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
+            ),
         ),
     ]
 
@@ -246,7 +258,9 @@ def step_impl(context, cube_name: str):
         QbColumn("D", NewQbDimension.from_data("D code list", _standard_data["D"])),
         QbColumn(
             "Value",
-            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
+            QbObservationValue(
+                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
+            ),
         ),
     ]
 
@@ -277,7 +291,9 @@ def step_impl(context, cube_name: str):
         ),
         QbColumn(
             "Value",
-            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
+            QbObservationValue(
+                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
+            ),
         ),
     ]
 
@@ -357,7 +373,9 @@ def step_impl(context, cube_name: str):
         ),
         QbColumn(
             "Value",
-            QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
+            QbObservationValue(
+                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
+            ),
         ),
     ]
 
@@ -465,7 +483,9 @@ def step_impl(context, cube_name: str, type: str, data_type: str):
     dim = QbColumn("A", NewQbDimension.from_data("A Dimension", data["A"]))
     val = QbColumn(
         "Value",
-        QbObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")),
+        QbObservationValue(
+            NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
+        ),
     )
     if data_type == "int":
         if type == "new":
@@ -549,7 +569,9 @@ def step_impl(context, cube_name: str):
         ),
         QbColumn(
             "Observed Value",
-            QbObservationValue(NewQbMeasure("Part-time"), NewQbUnit("Num of Students")),
+            QbObservationValue(
+                NewQbMeasure("Part-time"), NewQbUnit("Num of Students")
+            ),
         ),
     ]
 

--- a/tests/behaviour/steps/qbwriter.py
+++ b/tests/behaviour/steps/qbwriter.py
@@ -2,6 +2,7 @@ from genericpath import exists
 from http.client import OK
 from typing import List
 from urllib.parse import urlparse
+import os
 import pandas as pd
 from pathlib import Path
 from behave import Given, When, Then, Step
@@ -896,8 +897,7 @@ def assert_uri_style_for_uri(uri_style: URIStyle, uri: str, node):
 
 @then(u'the RDF should contain version specific triples')
 def step_impl(context):
-
-    context.version_triples = context.text + "\n" + f"prov:used <{get_csvcubed_version_uri()}> ."
+    context.version_triples = context.text + os.linesep + f"prov:used <{get_csvcubed_version_uri()}> ."
 
     test_graph_diff(
         Graph().parse(format="turtle", data=context.turtle),


### PR DESCRIPTION
Adresses ticket #614

Previously, the two behaviour tests which verified that the csvcubed version specific metadata triples has been serialised correctly to the resultant RDF contained a hardcoded value for the version URI which caused the tests to fail when running under any other tag.

This PR has changed these two tests by adding an additional step to each of their respective scenarios which construct the correct triples using the version util function created in the [original ticket](https://github.com/GSS-Cogs/csvcubed/issues/541).

The assertion uses the same devtools function as the step `and the RDF should contain` but this couldn’t be wholly reused for this fix because we needed to add the version function call to the step definition instead of calling from `context.text`.

The new step definition for `and the RDF should contain version specific triples` has been placed in `qbwriter` but I can understand if it would be more appropriate to have built this step definition in `csvcabed-devtools`.