### PR TITLE
Fixing a bug in windows testing (regarding QbWriter)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [
   {include = "csvcubed", from = "src"},
 ]
 readme = "README.md"
-version = "0.1.11"
+version = "0.1.0-dev"
 
 [tool.poetry.dependencies]
 pandas = "^1.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [
   {include = "csvcubed", from = "src"},
 ]
 readme = "README.md"
-version = "0.1.0-dev"
+version = "0.1.11"
 
 [tool.poetry.dependencies]
 pandas = "^1.3.3"

--- a/tests/behaviour/qbwriter.feature
+++ b/tests/behaviour/qbwriter.feature
@@ -629,7 +629,7 @@ Feature: Test outputting CSV-Ws with Qb flavouring.
     <file:/tmp/cube-data-convention-ok.csv#measure/cost-of-living-index> <http://www.w3.org/2000/01/rdf-schema#label> "Cost of living index"@en;
       <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#decimal> .
     """
-    
+
   Scenario: A QbCube should generate csvcubed version specific rdf
     Given a single-measure QbCube with identifier "qb-id-10002" named "Some Qube"
     When the cube is serialised to CSV-W
@@ -639,10 +639,10 @@ Feature: Test outputting CSV-Ws with Qb flavouring.
     And csv2rdf on all CSV-Ws should succeed
     And the RDF should contain version specific triples
     """
-    @prefix prov: <http://www.w3.org/ns/prov#> .
-
-    <file:/tmp/a-code-list.csv#code-list> a prov:Entity ;
-      prov:wasGeneratedBy <file:/tmp/a-code-list.csv#csvcubed-build-activity> .
-
+    @prefix prov: <http://www.w3.org/ns/prov#>. 
+    
+    <file:/tmp/a-code-list.csv#code-list> a prov:Entity; 
+      prov:wasGeneratedBy <file:/tmp/a-code-list.csv#csvcubed-build-activity>. 
+    
     <file:/tmp/qb-id-10002.csv#csvcubed-build-activity> a prov:Activity;
     """

--- a/tests/behaviour/steps/qbwriter.py
+++ b/tests/behaviour/steps/qbwriter.py
@@ -2,7 +2,7 @@ from genericpath import exists
 from http.client import OK
 from typing import List
 from urllib.parse import urlparse
-import os
+import re
 import pandas as pd
 from pathlib import Path
 from behave import Given, When, Then, Step
@@ -897,9 +897,11 @@ def assert_uri_style_for_uri(uri_style: URIStyle, uri: str, node):
 
 @then(u'the RDF should contain version specific triples')
 def step_impl(context):
-    context.version_triples = context.text + os.linesep + f"prov:used <{get_csvcubed_version_uri()}> ."
+    version_triples = (context.text + f" prov:used <{get_csvcubed_version_uri()}> .").strip()
+    version_triples = re.sub("\r", "", version_triples) # windows problem   
 
+    version_triples_graph = Graph().parse(format="turtle", data=version_triples)
     test_graph_diff(
         Graph().parse(format="turtle", data=context.turtle),
-        Graph().parse(format="turtle", data=context.version_triples.strip()),
+        version_triples_graph,
     )


### PR DESCRIPTION
rdflib raised a syntax error due to the "\r" char that was being picked up on the windows machine.
