### PR TITLE
Rename pandas categories without inviting deprecation warning

### DIFF
--- a/src/csvcubed/utils/qb/standardise.py
+++ b/src/csvcubed/utils/qb/standardise.py
@@ -79,11 +79,17 @@ def ensure_int_columns_are_ints(cube: QbCube) -> None:
         assert cube.data is not None
         try:
             if data_type in _signed_integer_data_types:
-                cube.data[column_title] = cube.data[column_title].astype(pd.Int64Dtype())
+                cube.data[column_title] = cube.data[column_title].astype(
+                    pd.Int64Dtype()
+                )
             elif data_type in _unsigned_integer_data_types:
-                cube.data[column_title] = cube.data[column_title].astype(pd.UInt64Dtype())
+                cube.data[column_title] = cube.data[column_title].astype(
+                    pd.UInt64Dtype()
+                )
         except Exception as err:
-            raise Exception(f'Column {column_title} failing,csvw  data type was {data_type}, pandas data type was {cube.data[column_title].dtype}') from err
+            raise Exception(
+                f"Column {column_title} failing,csvw  data type was {data_type}, pandas data type was {cube.data[column_title].dtype}"
+            ) from err
 
     for obs_val_col in get_columns_of_dsd_type(cube, QbObservationValue):
         _coerce_to_int_values_if_int(
@@ -192,7 +198,7 @@ def _overwrite_labels_for_columns(
 ) -> None:
     if cube.data is None:
         return
-        
+
     for column in affected_columns:
         column_data = cube.data[column.csv_column_title]
         assert column_data is not None
@@ -213,4 +219,6 @@ def _overwrite_labels_for_columns(
             else:
                 new_category_labels.append(new_category_label)
 
-        column_values.categories = new_category_labels
+        cube.data[column.csv_column_title] = column_values.rename_categories(
+            new_category_labels
+        )

--- a/tests/unit/cli/inspect/test_inspectdatasetmanager.py
+++ b/tests/unit/cli/inspect/test_inspectdatasetmanager.py
@@ -443,18 +443,19 @@ def test_get_val_counts_info_multi_unit_multi_measure_dataset():
         canonical_shape_dataset, measure_col, unit_col
     )
 
-    _expected_by_measure_and_unit_val_counts_df_multi_unit_multi_measure.rename(
-        columns={
-            "Measure": measure_col,
-            "Unit": unit_col,
-        },
-        inplace=True,
+    expected_by_measure_and_unit_val_counts_df_multi_unit_multi_measure = (
+        _expected_by_measure_and_unit_val_counts_df_multi_unit_multi_measure.rename(
+            columns={
+                "Measure": measure_col,
+                "Unit": unit_col,
+            },
+        )
     )
 
     assert result is not None
     assert_frame_equal(
         result.by_measure_and_unit_val_counts_df,
-        _expected_by_measure_and_unit_val_counts_df_multi_unit_multi_measure,
+        expected_by_measure_and_unit_val_counts_df_multi_unit_multi_measure,
     )
 
 
@@ -489,18 +490,19 @@ def test_get_val_counts_info_multi_unit_single_measure_dataset():
         canonical_shape_dataset, measure_col, unit_col
     )
 
-    _expected_by_measure_and_unit_val_counts_df_multi_unit_single_measure.rename(
-        columns={
-            "Measure": measure_col,
-            "Unit": unit_col,
-        },
-        inplace=True,
+    expected_by_measure_and_unit_val_counts_df_multi_unit_single_measure = (
+        _expected_by_measure_and_unit_val_counts_df_multi_unit_single_measure.rename(
+            columns={
+                "Measure": measure_col,
+                "Unit": unit_col,
+            }
+        )
     )
 
     assert result is not None
     assert_frame_equal(
         result.by_measure_and_unit_val_counts_df,
-        _expected_by_measure_and_unit_val_counts_df_multi_unit_single_measure,
+        expected_by_measure_and_unit_val_counts_df_multi_unit_single_measure,
     )
 
 
@@ -535,18 +537,19 @@ def test_get_val_counts_info_single_unit_multi_measure_dataset():
         canonical_shape_dataset, measure_col, unit_col
     )
 
-    _expected_by_measure_and_unit_val_counts_df_single_unit_multi_measure.rename(
-        columns={
-            "Measure": measure_col,
-            "Unit": unit_col,
-        },
-        inplace=True,
+    expected_by_measure_and_unit_val_counts_df_single_unit_multi_measure = (
+        _expected_by_measure_and_unit_val_counts_df_single_unit_multi_measure.rename(
+            columns={
+                "Measure": measure_col,
+                "Unit": unit_col,
+            },
+        )
     )
 
     assert result is not None
     assert_frame_equal(
         result.by_measure_and_unit_val_counts_df,
-        _expected_by_measure_and_unit_val_counts_df_single_unit_multi_measure,
+        expected_by_measure_and_unit_val_counts_df_single_unit_multi_measure,
     )
 
 
@@ -581,18 +584,19 @@ def test_get_val_counts_info_single_unit_single_measure_dataset():
         canonical_shape_dataset, measure_col, unit_col
     )
 
-    _expected_by_measure_and_unit_val_counts_df_single_unit_single_measure.rename(
-        columns={
-            "Measure": measure_col,
-            "Unit": unit_col,
-        },
-        inplace=True,
+    expected_by_measure_and_unit_val_counts_df_single_unit_single_measure = (
+        _expected_by_measure_and_unit_val_counts_df_single_unit_single_measure.rename(
+            columns={
+                "Measure": measure_col,
+                "Unit": unit_col,
+            },
+        )
     )
 
     assert result is not None
     assert_frame_equal(
         result.by_measure_and_unit_val_counts_df,
-        _expected_by_measure_and_unit_val_counts_df_single_unit_single_measure,
+        expected_by_measure_and_unit_val_counts_df_single_unit_single_measure,
     )
 
 
@@ -615,8 +619,10 @@ def test_get_concepts_hierarchy_info_hierarchy_with_depth_of_one():
     result_code_list_cols = select_codelist_cols_by_dataset_url(
         csvw_metadata_rdf_graph, dataset_url
     )
-    result_primary_key_col_names_by_dataset_url = select_primary_key_col_names_by_dataset_url(
-        csvw_metadata_rdf_graph, dataset_url
+    result_primary_key_col_names_by_dataset_url = (
+        select_primary_key_col_names_by_dataset_url(
+            csvw_metadata_rdf_graph, dataset_url
+        )
     )
 
     parent_notation_col_name = get_codelist_col_title_by_property_url(
@@ -626,7 +632,8 @@ def test_get_concepts_hierarchy_info_hierarchy_with_depth_of_one():
         result_code_list_cols.columns, CodelistPropertyUrl.RDFLabel
     )
     unique_identifier = get_codelist_col_title_from_col_name(
-        result_code_list_cols.columns, result_primary_key_col_names_by_dataset_url.primary_key_col_names[0].value
+        result_code_list_cols.columns,
+        result_primary_key_col_names_by_dataset_url.primary_key_col_names[0].value,
     )
 
     result = get_concepts_hierarchy_info(
@@ -653,8 +660,10 @@ def test_get_concepts_hierarchy_info_hierarchy_with_depth_more_than_one():
     result_code_list_cols = select_codelist_cols_by_dataset_url(
         csvw_metadata_rdf_graph, dataset_url
     )
-    result_primary_key_col_names_by_dataset_url = select_primary_key_col_names_by_dataset_url(
-        csvw_metadata_rdf_graph, dataset_url
+    result_primary_key_col_names_by_dataset_url = (
+        select_primary_key_col_names_by_dataset_url(
+            csvw_metadata_rdf_graph, dataset_url
+        )
     )
 
     parent_notation_col_name = get_codelist_col_title_by_property_url(
@@ -664,7 +673,8 @@ def test_get_concepts_hierarchy_info_hierarchy_with_depth_more_than_one():
         result_code_list_cols.columns, CodelistPropertyUrl.RDFLabel
     )
     unique_identifier = get_codelist_col_title_from_col_name(
-        result_code_list_cols.columns, result_primary_key_col_names_by_dataset_url.primary_key_col_names[0].value
+        result_code_list_cols.columns,
+        result_primary_key_col_names_by_dataset_url.primary_key_col_names[0].value,
     )
 
     result = get_concepts_hierarchy_info(


### PR DESCRIPTION
Renaming categories on a pandas datacolumn in an in-place fashion yields a deprecation warning which isn't helpful for external users to see. 

This PR addresses #626 by avoiding in-place renaming of categories.

I also took the opportunity to remove some inplace replacements running in unrelated unit tests. Future versions of pandas will not support in-place replacement at all.