### PR TITLE
Ensuring we don't publish documentation for pre-release versions

### DIFF
--- a/.github/workflows/reusable-deploy.yaml
+++ b/.github/workflows/reusable-deploy.yaml
@@ -22,9 +22,15 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          
+      - name: is-final-release 
+        if: startsWith(github.ref, 'refs/tags/v') 
+        run: | 
+          [[ ! {{github.ref_name}} =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]
+        continue-on-error: true
 
       - name: Publish Docs
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: steps.is-final-release.outcome == 'success' && startsWith(github.ref, 'refs/tags/v')
         run: |
           git config --global user.email "csvcubed@gsscogs.uk" && git config --global user.name "csvcubed"
 


### PR DESCRIPTION
Added in the extra check for Pre-release tag(-rc before the last digit in the tag).