### PR TITLE
#715 - Filtering column JSON schema error messages displayed based on `type`.

### DIFF
--- a/src/csvcubed/models/jsonvalidationerrors.py
+++ b/src/csvcubed/models/jsonvalidationerrors.py
@@ -167,6 +167,7 @@ class AnyOneOfJsonSchemaValidationError(JsonSchemaValidationError):
                     ),
                     _indent,
                 )
+                + os.linesep
             )
 
         return indent(child_error_messages, _indent)

--- a/src/csvcubed/schema/cube-config/v1_4/schema.json
+++ b/src/csvcubed/schema/cube-config/v1_4/schema.json
@@ -63,6 +63,7 @@
             "description": "Map of CSV column titles to definitions of what the column represents (a dimension, an attribute, observations, units or measures). If a column needs to be suppressed (i.e. skipped), the following notation can be used: {'column_name': false}",
             "additionalProperties": {
                 "description": "Column's meaning in the data cube",
+                "$comment": "ATTENTION: If you ADD any column types below, you MUST UPDATE csvcubed.readers.cubeconfig.v1.configdeserialiser._map_column_type_to_schema_type_refs to reflect your changes.",
                 "anyOf": [
                     {
                         "$ref": "#/definitions/v1.0/columnTypes/Dimension"

--- a/tests/test-cases/readers/cube-config/v1.0/schema_validation_errors/all_column_types_badly_defined.json
+++ b/tests/test-cases/readers/cube-config/v1.0/schema_validation_errors/all_column_types_badly_defined.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://purl.org/csv-cubed/qube-config/v1",
+  "id": "Schema cube data config ok",
+  "title": "Tests/test-cases/config/schema-cube-data-config-ok",
+  "description": "Schema for testing",
+  "creator": "https://www.gov.uk/government/organisations/office-for-national-statistics",
+  "publisher": "http://statistics.data.gov.uk",
+  "spatial_bound": "spatial",
+  "temporal_bound": "temporal",
+  "dataset_issued": "2022-03-04",
+  "dataset_modified": "2022-03-04T15:00:00Z",
+  "public_contact_point": "mailto:csvcubed@example.com",
+  "license": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+  "summary": "a summary",
+  "keywords": [
+    "A keyword",
+    "Another keyword"
+  ],
+  "themes": [
+    "https://www.ons.gov.uk/economy/nationalaccounts/balanceofpayments"
+  ],
+  "columns": {
+    "Dim-0": {
+      "label": "Non Dimension",
+      "type": "dimension",
+      "code_list": true,
+      "from_existing": "http://example.com/dimensions/trade-direction"
+    },
+    "Dim-1": {
+      "type": "dimension",
+      "label": "Period Dimension",
+      "code_list": true
+    },
+    "Dim-2": {
+      "type": "dimension",
+      "label": "Trade Direction Dimension",
+      "code_list": true
+    },
+    "Attr-1": {
+      "type": "attribute",
+      "label": "My best attribute",
+      "from_existing": "http://example.com/attributes/some-attribute"
+    },
+    "Amount": {
+      "type": "observations",
+      "shouldn't": "be here"
+    },
+    "Measure": {
+      "type": "measures",
+      "values": [
+        {
+          "label": "Monetary Value",
+          "from_existing": "http://example.com/measures/some-measure"
+        }
+      ]
+    },
+    "Units": {
+      "type": "units",
+      "values": [
+        {
+          "label": "Pounds",
+          "from_existing": "http://example.com/units/some-unit"
+        }
+      ]
+    }
+  }
+}

--- a/tests/test-cases/readers/cube-config/v1.0/schema_validation_errors/all_column_types_badly_defined.json
+++ b/tests/test-cases/readers/cube-config/v1.0/schema_validation_errors/all_column_types_badly_defined.json
@@ -27,9 +27,8 @@
       "from_existing": "http://example.com/dimensions/trade-direction"
     },
     "Dim-1": {
-      "type": "dimension",
       "label": "Period Dimension",
-      "code_list": true
+      "from_existing": "http://example.com/dimensions/trade-direction"
     },
     "Dim-2": {
       "type": "dimension",

--- a/tests/unit/readers/cubeconfig/v1_0/test_json_schema_validation_errors.py
+++ b/tests/unit/readers/cubeconfig/v1_0/test_json_schema_validation_errors.py
@@ -1,10 +1,14 @@
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Set
 
 import pytest
 
-from csvcubed.models.jsonvalidationerrors import JsonSchemaValidationError
+from csvcubed.models.jsonvalidationerrors import (
+    JsonSchemaValidationError,
+    AnyOneOfJsonSchemaValidationError,
+)
 from csvcubed.readers.cubeconfig.schema_versions import get_deserialiser_for_schema
+from csvcubed.utils.iterables import first
 from tests.unit.test_baseunit import get_test_cases_dir
 
 TEST_CASE_DIR = get_test_cases_dir().absolute() / "readers" / "cube-config" / "v1.0"
@@ -80,9 +84,89 @@ def test_json_schema_validation_error_to_dict():
     assert "schema" not in dict
 
     # Ensure the functionality to remove the `schema` variable applies recursively to child errors.
-    child_error = dict["possible_types_with_grouped_errors"][0][1][1]
+    child_error = dict["possible_types_with_grouped_errors"][0][1][0]
     assert "message" in child_error
     assert "schema" not in child_error
+
+
+@pytest.mark.vcr
+def test_qube_config_columns_filtered_by_type():
+    """
+    Ensure that qube-config.json errors in column definitions are filtered by the `type` specified in the config file.
+    """
+    deserialiser = get_deserialiser_for_schema(None)
+    _, json_schema_errors, _ = deserialiser(
+        TEST_CASE_DIR / "schema_validation_errors" / "data.csv",
+        TEST_CASE_DIR
+        / "schema_validation_errors"
+        / "all_column_types_badly_defined.json",
+    )
+
+    def assert_column_error_has_possible_types(
+        column_title: str, expected_possible_schema_type_refs: Set[str]
+    ):
+        error_for_column = first(
+            json_schema_errors, lambda e: e.json_path == f"$.columns.{column_title}"
+        )
+        assert isinstance(error_for_column, AnyOneOfJsonSchemaValidationError)
+        actual_possible_schema_type_refs = {
+            possible_schema_type.get("$ref")
+            for (
+                possible_schema_type,
+                _,
+            ) in error_for_column.possible_types_with_grouped_errors
+        }
+
+        assert actual_possible_schema_type_refs == expected_possible_schema_type_refs
+
+    # Expecting errors in `Dim-0`, `Dim-1`, `Attr-1`, `Amount`, `Measure` & `Units` columns.
+    assert len(json_schema_errors) == 6
+
+    assert_column_error_has_possible_types(
+        "Dim-0", {"#/definitions/v1.0/columnTypes/Dimension"}
+    )
+    assert_column_error_has_possible_types(
+        "Attr-1",
+        {
+            "#/definitions/v1.0/columnTypes/Attribute_Resource_New",
+            "#/definitions/v1.0/columnTypes/Attribute_Resource_Existing",
+            "#/definitions/v1.0/columnTypes/Attribute_Literal",
+        },
+    )
+    assert_column_error_has_possible_types(
+        "Amount", {"#/definitions/v1.0/columnTypes/Observations"}
+    )
+    assert_column_error_has_possible_types(
+        "Measure",
+        {
+            "#/definitions/v1.0/columnTypes/Measures_New",
+            "#/definitions/v1.0/columnTypes/Measures_Existing",
+        },
+    )
+    assert_column_error_has_possible_types(
+        "Units",
+        {
+            "#/definitions/v1.0/columnTypes/Units_New",
+            "#/definitions/v1.0/columnTypes/Units_Existing",
+        },
+    )
+
+    # Assert that Dim-1 which doesn't have `type` specified at all brings back all of the column definition types.
+    assert_column_error_has_possible_types(
+        "Dim-1",
+        {
+            None,  # This represents the `false` boolean which is defined inline without using `$ref`.
+            "#/definitions/v1.0/columnTypes/Attribute_Literal",
+            "#/definitions/v1.0/columnTypes/Attribute_Resource_Existing",
+            "#/definitions/v1.0/columnTypes/Attribute_Resource_New",
+            "#/definitions/v1.0/columnTypes/Dimension",
+            "#/definitions/v1.0/columnTypes/Measures_Existing",
+            "#/definitions/v1.0/columnTypes/Measures_New",
+            "#/definitions/v1.0/columnTypes/Observations",
+            "#/definitions/v1.0/columnTypes/Units_Existing",
+            "#/definitions/v1.0/columnTypes/Units_New",
+        },
+    )
 
 
 def _assert_single_json_schema_validation_error_message(


### PR DESCRIPTION
Does what it says on the tin. I've added a test case which demonstrates this functionality. The following is an example of how each column type behaves:


```
$ csvcubed build data.csv --config all_column_types_badly_defined.json
2023-02-20 12:15:58,034 - csvcubed.cli.build - WARNING - Schema Validation Error: $.columns.Amount - Unable to identify {'type': 'observations', "shouldn't": 'be here'}

    If you meant to declare 'This column holds observed/recorded values', then:
        - Additional properties are not allowed ("shouldn't" was unexpected)
 (build.py:101)
2023-02-20 12:15:58,035 - csvcubed.cli.build - WARNING - Schema Validation Error: $.columns.Attr-1 - Unable to identify {'type': 'attribute', 'label': 'My best attribute', 'from_existing': 'http://example.com/attributes/some-attribute'}

    If you meant to declare 'This column represents an attribute (with resource values) of the cube (creating a new attribute)', then:
        $.from_existing - 'http://example.com/attributes/some-attribute' is not recognised by csvcubed.


    If you meant to declare 'This column represents an attribute (with resource values) of the cube (reusing an existing attribute definition)', then:
        $.from_existing - 'http://example.com/attributes/some-attribute' is not recognised by csvcubed.


    If you meant to declare 'This column represents an attribute (with literal values) of the cube', then:
        $.from_existing - 'http://example.com/attributes/some-attribute' is not recognised by csvcubed.
 (build.py:101)
2023-02-20 12:15:58,035 - csvcubed.cli.build - WARNING - Schema Validation Error: $.columns.Dim-0 - Unable to identify {'label': 'Non Dimension', 'type': 'dimension', 'code_list': True, 'from_existing': 'http://example.com/dimensions/trade-direction…

    If you meant to declare 'This column represents a dimension of the cube', then:
        $.from_existing - 'http://example.com/dimensions/trade-direction' is not recognised by csvcubed.
 (build.py:101)
2023-02-20 12:15:58,035 - csvcubed.cli.build - WARNING - Schema Validation Error: $.columns.Measure - Unable to identify {'type': 'measures', 'values': [{'label': 'Monetary Value', 'from_existing': 'http://example.com/measures/some-measure'}]}

    If you meant to declare 'This column represents the phenomenon which has been measured (defining new measures)', then:
        $.values - Unable to identify [{'label': 'Monetary Value', 'from_existing': 'http://example.com/measures/some-measure'}]

            If you meant to declare 'true/false - whether to automatically generate measures for each unique value in the column', then:
                - [{'label': 'Monetary Value', 'from_existing': 'http://example.com/measures/some-measure'}] is not of type 'boolean'


            If you meant to declare 'The list of measures permitted in this column', then:
                $[0].from_existing - 'http://example.com/measures/some-measure' is not recognised by csvcubed.



    If you meant to declare 'This column represents the phenomenon which has been measured (reusing existing measure definitions)', then:
        - Additional properties are not allowed ('values' was unexpected)
 (build.py:101)
2023-02-20 12:15:58,036 - csvcubed.cli.build - WARNING - Schema Validation Error: $.columns.Units - Unable to identify {'type': 'units', 'values': [{'label': 'Pounds', 'from_existing': 'http://example.com/units/some-unit'}]}

    If you meant to declare 'This column represents the unit of measure in which observations were recorded (defining new units)', then:
        $.values - Unable to identify [{'label': 'Pounds', 'from_existing': 'http://example.com/units/some-unit'}]

            If you meant to declare 'true/false - whether to automatically generate new units from the unique values in this column', then:
                - [{'label': 'Pounds', 'from_existing': 'http://example.com/units/some-unit'}] is not of type 'boolean'


            If you meant to declare 'The list of distinct units in this column', then:
                $[0].from_existing - 'http://example.com/units/some-unit' is not recognised by csvcubed.



    If you meant to declare 'This column represents the unit of measure in which observations were recorded (reusing existing unit definitions)', then:
        - Additional properties are not allowed ('values' was unexpected)
 (build.py:101)
Build Complete @ /Users/HA9WF3CZ/Code/csvcubed/tests/test-cases/readers/cube-config/v1.0/schema_validation_errors/out
``` 

You'll notice that you only get errors relevant to the type of the column you specified. However, if you fail to specify the `type` in a column, you still get the full list of possible matching types (and their error messages) printed.

Satisfies #715.