### PR TITLE
676 validate model properties error

### DIFF
--- a/src/csvcubed/models/cube/catalog.py
+++ b/src/csvcubed/models/cube/catalog.py
@@ -9,7 +9,7 @@ from typing import Dict, Optional, Union
 
 from csvcubed.models.pydanticmodel import PydanticModel
 from csvcubed.models.validatedmodel import ValidatedModel, ValidationFunction
-from csvcubed.utils.validations import validate_str_type
+from csvcubed.utils import validations as v
 
 
 @dataclass
@@ -25,4 +25,4 @@ class CatalogMetadataBase(PydanticModel, ValidatedModel, ABC):
         pass
 
     def _get_validations(self) -> Dict[str, ValidationFunction]:
-        return {"title": validate_str_type}
+        return {"title": v.string}

--- a/src/csvcubed/models/cube/columns.py
+++ b/src/csvcubed/models/cube/columns.py
@@ -11,7 +11,7 @@ from csvcubed.models.pydanticmodel import PydanticModel
 from csvcubed.models.uriidentifiable import UriIdentifiable
 from csvcubed.models.validatedmodel import ValidationFunction
 from csvcubed.models.validationerror import ValidationError
-from csvcubed.utils.validations import validate_str_type
+from csvcubed.utils import validations as v
 
 
 @dataclass
@@ -26,7 +26,7 @@ class CsvColumn(PydanticModel, UriIdentifiable, ABC):
         pass
 
     def _get_validations(self) -> Dict[str, ValidationFunction]:
-        return {"csv_column_title": validate_str_type}
+        return {"csv_column_title": v.string}
 
 
 @dataclass

--- a/src/csvcubed/models/cube/qb/catalog.py
+++ b/src/csvcubed/models/cube/qb/catalog.py
@@ -16,12 +16,6 @@ from csvcubed.models.uriidentifiable import UriIdentifiable
 from csvcubed.models.validatedmodel import ValidatedModel, ValidationFunction
 from csvcubed.models.validationerror import ValidateModelPropertiesError
 from csvcubed.utils import validations as v
-from csvcubed.utils.validations import (
-    validate_list,
-    validate_optional,
-    validate_str_type,
-    validate_uri,
-)
 from csvcubed.utils.validators.uri import validate_uri as pydantic_validate_uri
 from csvcubed.utils.validators.uri import (
     validate_uris_in_list as pydantic_validate_uris_in_list,
@@ -63,22 +57,22 @@ class CatalogMetadata(CatalogMetadataBase, UriIdentifiable):
     def _get_validations(self) -> Dict[str, ValidationFunction]:
         return {
             **CatalogMetadataBase._get_validations(self),
-            "identifier": validate_optional(validate_str_type),
-            "summary": validate_optional(validate_str_type),
-            "description": validate_optional(validate_str_type),
-            "creator_uri": validate_optional(validate_uri),
-            "publisher_uri": validate_optional(validate_uri),
-            "landing_page_uris": validate_list(validate_uri),
-            "theme_uris": validate_list(validate_uri),
-            "keywords": validate_list(validate_str_type),
-            "dataset_issued": validate_optional(
+            "identifier": v.optional(v.string),
+            "summary": v.optional(v.string),
+            "description": v.optional(v.string),
+            "creator_uri": v.optional(v.uri),
+            "publisher_uri": v.optional(v.uri),
+            "landing_page_uris": v.list(v.uri),
+            "theme_uris": v.list(v.uri),
+            "keywords": v.list(v.string),
+            "dataset_issued": v.optional(
                 v.any_of(v.is_instance_of(date), v.is_instance_of(datetime))
             ),
-            "dataset_modified": validate_optional(
+            "dataset_modified": v.optional(
                 v.any_of(v.is_instance_of(date), v.is_instance_of(datetime))
             ),
-            "license_uri": validate_optional(validate_uri),
-            "public_contact_point_uri": validate_optional(validate_uri),
+            "license_uri": v.optional(v.uri),
+            "public_contact_point_uri": v.optional(v.uri),
             **UriIdentifiable._get_validations(self),
         }
 

--- a/src/csvcubed/models/cube/qb/columns.py
+++ b/src/csvcubed/models/cube/qb/columns.py
@@ -13,7 +13,6 @@ from csvcubed.models.uriidentifiable import UriIdentifiable
 from csvcubed.models.validatedmodel import ValidationFunction
 from csvcubed.utils import validations as v
 from csvcubed.utils.uri import csvw_column_name_safe
-from csvcubed.utils.validations import validate_optional, validate_str_type
 
 from ...validationerror import ValidationError
 from .components.datastructuredefinition import QbColumnStructuralDefinition
@@ -57,8 +56,8 @@ class QbColumn(CsvColumn, Generic[QbColumnStructuralDefinition]):
         return {
             **CsvColumn._get_validations(self),
             "structural_definition": v.validated_model(QbColumnStructuralDefinition),
-            "csv_column_uri_template": validate_optional(
-                validate_str_type,
+            "csv_column_uri_template": v.optional(
+                v.string,
             ),
             **UriIdentifiable._get_validations(self),
         }

--- a/src/csvcubed/models/cube/qb/components/arbitraryrdf.py
+++ b/src/csvcubed/models/cube/qb/components/arbitraryrdf.py
@@ -58,7 +58,7 @@ class TripleFragmentBase(PydanticModel, ValidatedModel, ABC):
     predicate: Union[str, URIRef]
 
     def _get_validations(self) -> Union[Validations, Dict[str, ValidationFunction]]:
-        return {"predicate": v.any_of(v.validate_str_type, v.is_instance_of(URIRef))}
+        return {"predicate": v.any_of(v.string, v.is_instance_of(URIRef))}
 
 
 @dataclass(unsafe_hash=True)
@@ -78,7 +78,7 @@ class TripleFragment(TripleFragmentBase):
         assert isinstance(triple_fragment_base_property_validations, dict)
 
         return {
-            "object": v.any_of(v.validate_str_type, v.is_instance_of(Identifier)),
+            "object": v.any_of(v.string, v.is_instance_of(Identifier)),
             "subject_hint": v.enum(RdfSerialisationHint),
             **triple_fragment_base_property_validations,
         }
@@ -101,7 +101,7 @@ class InverseTripleFragment(TripleFragmentBase):
         assert isinstance(triple_fragment_base_property_validations, dict)
         return {
             "subject": v.any_of(
-                v.validate_str_type, v.is_instance_of(expect_instance_type=Identifier)
+                v.string, v.is_instance_of(expect_instance_type=Identifier)
             ),
             "object_hint": v.enum(RdfSerialisationHint),
             **triple_fragment_base_property_validations,

--- a/src/csvcubed/models/cube/qb/components/attribute.py
+++ b/src/csvcubed/models/cube/qb/components/attribute.py
@@ -20,11 +20,6 @@ from csvcubed.models.validationerror import ValidationError
 from csvcubed.utils import validations as v
 from csvcubed.utils.qb.validation.uri_safe import ensure_no_uri_safe_conflicts
 from csvcubed.utils.uri import uri_safe
-from csvcubed.utils.validations import (
-    validate_list,
-    validate_optional,
-    validate_str_type,
-)
 from csvcubed.utils.validators.uri import validate_uri as pydantic_validate_uri
 
 from .arbitraryrdf import ArbitraryRdf, RdfSerialisationHint, TripleFragmentBase
@@ -123,13 +118,11 @@ class ExistingQbAttribute(QbAttribute):
 
     def _get_validations(self) -> Dict[str, ValidationFunction]:
         return {
-            "attribute_uri": v.validate_uri,
-            "new_attribute_values": validate_list(
-                v.validated_model(NewQbAttributeValue)
-            ),
+            "attribute_uri": v.uri,
+            "new_attribute_values": v.list(v.validated_model(NewQbAttributeValue)),
             "is_required": v.boolean,
-            "arbitrary_rdf": validate_list(v.validated_model(TripleFragmentBase)),
-            "observed_value_col_title": validate_optional(validate_str_type),
+            "arbitrary_rdf": v.list(v.validated_model(TripleFragmentBase)),
+            "observed_value_col_title": v.optional(v.string),
         }
 
 
@@ -226,17 +219,15 @@ class NewQbAttribute(QbAttribute, UriIdentifiable):
 
     def _get_validations(self) -> Dict[str, ValidationFunction]:
         return {
-            "label": validate_str_type,
-            "description": validate_optional(validate_str_type),
-            "new_attribute_values": validate_list(
-                v.validated_model(NewQbAttributeValue)
-            ),
-            "parent_attribute_uri": validate_optional(v.validate_uri),
-            "source_uri": validate_optional(v.validate_uri),
+            "label": v.string,
+            "description": v.optional(v.string),
+            "new_attribute_values": v.list(v.validated_model(NewQbAttributeValue)),
+            "parent_attribute_uri": v.optional(v.uri),
+            "source_uri": v.optional(v.uri),
             "is_required": v.boolean,
             **UriIdentifiable._get_validations(self),
-            "arbitrary_rdf": validate_list(v.validated_model(TripleFragmentBase)),
-            "observed_value_col_title": validate_optional(validate_str_type),
+            "arbitrary_rdf": v.list(v.validated_model(TripleFragmentBase)),
+            "observed_value_col_title": v.optional(v.string),
         }
 
 
@@ -255,7 +246,7 @@ class QbAttributeLiteral(QbAttribute, ABC):
         return data_type
 
     def _get_validations(self) -> Dict[str, ValidationFunction]:
-        return {"data_type": v.any_of(v.data_type, v.validate_uri)}
+        return {"data_type": v.any_of(v.data_type, v.uri)}
 
 
 @dataclass
@@ -283,11 +274,9 @@ class ExistingQbAttributeLiteral(ExistingQbAttribute, QbAttributeLiteral):
         return {
             **QbAttributeLiteral._get_validations(self),
             **ExistingQbAttribute._get_validations(self),
-            "new_attribute_values": validate_list(
-                v.validated_model(NewQbAttributeValue)
-            ),
-            "arbitrary_rdf": validate_list(v.validated_model(TripleFragmentBase)),
-            "observed_value_col_title": validate_optional(validate_str_type),
+            "new_attribute_values": v.list(v.validated_model(NewQbAttributeValue)),
+            "arbitrary_rdf": v.list(v.validated_model(TripleFragmentBase)),
+            "observed_value_col_title": v.optional(v.string),
         }
 
 
@@ -319,9 +308,7 @@ class NewQbAttributeLiteral(NewQbAttribute, QbAttributeLiteral):
         return {
             **QbAttributeLiteral._get_validations(self),
             **NewQbAttribute._get_validations(self),
-            "new_attribute_values": validate_list(
-                v.validated_model(NewQbAttributeValue)
-            ),
-            "arbitrary_rdf": validate_list(v.validated_model(TripleFragmentBase)),
-            "observed_value_col_title": validate_optional(validate_str_type),
+            "new_attribute_values": v.list(v.validated_model(NewQbAttributeValue)),
+            "arbitrary_rdf": v.list(v.validated_model(TripleFragmentBase)),
+            "observed_value_col_title": v.optional(v.string),
         }

--- a/src/csvcubed/models/cube/qb/components/attributevalue.py
+++ b/src/csvcubed/models/cube/qb/components/attributevalue.py
@@ -11,12 +11,6 @@ from typing import Dict, List, Optional, Set
 from csvcubed.models.uriidentifiable import UriIdentifiable
 from csvcubed.models.validatedmodel import ValidationFunction
 from csvcubed.utils import validations as v
-from csvcubed.utils.validations import (
-    validate_list,
-    validate_optional,
-    validate_str_type,
-    validate_uri,
-)
 
 from .arbitraryrdf import ArbitraryRdf, RdfSerialisationHint, TripleFragmentBase
 from .datastructuredefinition import SecondaryQbStructuralDefinition
@@ -48,10 +42,10 @@ class NewQbAttributeValue(
     def _get_validations(self) -> Dict[str, ValidationFunction]:
 
         return {
-            "label": validate_str_type,
-            "description": validate_optional(validate_str_type),
+            "label": v.string,
+            "description": v.optional(v.string),
             **UriIdentifiable._get_validations(self),
-            "source_uri": validate_optional(validate_uri),
-            "parent_attribute_value_uri": validate_optional(validate_uri),
-            "arbitrary_rdf": validate_list(v.validated_model(TripleFragmentBase)),
+            "source_uri": v.optional(v.uri),
+            "parent_attribute_value_uri": v.optional(v.uri),
+            "arbitrary_rdf": v.list(v.validated_model(TripleFragmentBase)),
         }

--- a/src/csvcubed/models/cube/qb/components/codelist.py
+++ b/src/csvcubed/models/cube/qb/components/codelist.py
@@ -114,21 +114,22 @@ class NewQbCodeListInCsvW(QbCodeList):
 
     @staticmethod
     def _validation_csvw_sufficient_information(
-        self,
-    ) -> List[ValidateModelPropertiesError]:
+        value: "NewQbCodeListInCsvW", property_path: List[str]
+    ):
         errors: List[ValidateModelPropertiesError] = []
 
-        csv_path = self.csv_file_relative_path_or_uri
-        cs_uri = self.concept_scheme_uri
-        c_template_uri = self.concept_template_uri
+        csv_path = value.csv_file_relative_path_or_uri
+        cs_uri = value.concept_scheme_uri
+        c_template_uri = value.concept_template_uri
         if csv_path is None or cs_uri is None or c_template_uri is None:
-            schema_metadata_file_path = self.schema_metadata_file_path
+            schema_metadata_file_path = value.schema_metadata_file_path
             extract_code_list_concept_scheme_info(schema_metadata_file_path)
 
             errors.append(
                 ValidateModelPropertiesError(
                     "'csv_file_relative_path_or_uri', 'concept_scheme_uri' or 'concept_template_uri' values are missing.",
-                    "Whole Object",
+                    property_path,
+                    value,
                 )
             )
 

--- a/src/csvcubed/models/cube/qb/components/concept.py
+++ b/src/csvcubed/models/cube/qb/components/concept.py
@@ -10,13 +10,8 @@ from typing import Dict, Optional
 
 from csvcubed.models.uriidentifiable import UriIdentifiable
 from csvcubed.models.validatedmodel import ValidatedModel, ValidationFunction
+from csvcubed.utils import validations as v
 from csvcubed.utils.uri import uri_safe
-from csvcubed.utils.validations import (
-    validate_int_type,
-    validate_optional,
-    validate_str_type,
-    validate_uri,
-)
 from csvcubed.utils.validators.uri import validate_uri as pydantic_validate_uri
 
 from .datastructuredefinition import SecondaryQbStructuralDefinition
@@ -48,11 +43,11 @@ class NewQbConcept(SecondaryQbStructuralDefinition, UriIdentifiable):
     def _get_validations(self) -> Dict[str, ValidationFunction]:
 
         return {
-            "label": validate_str_type,
-            "code": validate_str_type,
-            "parent_code": validate_optional(validate_str_type),
-            "sort_order": validate_optional(validate_int_type),
-            "description": validate_optional(validate_str_type),
+            "label": v.string,
+            "code": v.string,
+            "parent_code": v.optional(v.string),
+            "sort_order": v.optional(v.integer),
+            "description": v.optional(v.string),
             **UriIdentifiable._get_validations(self),
         }
 
@@ -68,7 +63,7 @@ class ExistingQbConcept(SecondaryQbStructuralDefinition):
     def _get_validations(self) -> Dict[str, ValidationFunction]:
 
         return {
-            "existing_concept_uri": validate_uri,
+            "existing_concept_uri": v.uri,
         }
 
 

--- a/src/csvcubed/models/cube/qb/components/dimension.py
+++ b/src/csvcubed/models/cube/qb/components/dimension.py
@@ -25,12 +25,6 @@ from csvcubed.models.uriidentifiable import UriIdentifiable
 from csvcubed.models.validatedmodel import ValidationFunction
 from csvcubed.models.validationerror import ValidationError
 from csvcubed.utils import validations as v
-from csvcubed.utils.validations import (
-    validate_list,
-    validate_optional,
-    validate_str_type,
-    validate_uri,
-)
 from csvcubed.utils.validators.uri import validate_uri as pydantic_validate_uri
 
 from .codelist import NewQbCodeList, QbCodeList
@@ -49,7 +43,7 @@ class QbDimension(QbColumnStructuralDefinition, ArbitraryRdf, ABC):
         pass
 
     def _get_validations(self) -> Dict[str, ValidationFunction]:
-        return {"range_uri": validate_optional(validate_uri)}
+        return {"range_uri": v.optional(v.uri)}
 
 
 @dataclass
@@ -86,8 +80,8 @@ class ExistingQbDimension(QbDimension):
 
         return {
             **QbDimension._get_validations(self),
-            "dimension_uri": validate_uri,
-            "arbitrary_rdf": validate_list(v.validated_model(TripleFragmentBase)),
+            "dimension_uri": v.uri,
+            "arbitrary_rdf": v.list(v.validated_model(TripleFragmentBase)),
         }
 
 
@@ -158,11 +152,11 @@ class NewQbDimension(QbDimension, UriIdentifiable):
     def _get_validations(self) -> Dict[str, ValidationFunction]:
         return {
             **QbDimension._get_validations(self),
-            "label": validate_str_type,
-            "description": validate_optional(validate_str_type),
-            "code_list": validate_optional(v.validated_model(QbCodeList)),
-            "parent_dimension_uri": validate_optional(validate_uri),
-            "source_uri": validate_optional(validate_uri),
+            "label": v.string,
+            "description": v.optional(v.string),
+            "code_list": v.optional(v.validated_model(QbCodeList)),
+            "parent_dimension_uri": v.optional(v.uri),
+            "source_uri": v.optional(v.uri),
             **UriIdentifiable._get_validations(self),
-            "arbitrary_rdf": validate_list(v.validated_model(TripleFragmentBase)),
+            "arbitrary_rdf": v.list(v.validated_model(TripleFragmentBase)),
         }

--- a/src/csvcubed/models/cube/qb/components/measure.py
+++ b/src/csvcubed/models/cube/qb/components/measure.py
@@ -19,12 +19,6 @@ from csvcubed.models.cube.qb.components.arbitraryrdf import (
 from csvcubed.models.uriidentifiable import UriIdentifiable
 from csvcubed.models.validatedmodel import ValidationFunction
 from csvcubed.utils import validations as v
-from csvcubed.utils.validations import (
-    validate_list,
-    validate_optional,
-    validate_str_type,
-    validate_uri,
-)
 from csvcubed.utils.validators.uri import validate_uri as pydantic_validate_uri
 
 from .datastructuredefinition import SecondaryQbStructuralDefinition
@@ -65,8 +59,8 @@ class ExistingQbMeasure(QbMeasure):
     def _get_validations(self) -> Dict[str, ValidationFunction]:
 
         return {
-            "measure_uri": validate_uri,
-            "arbitrary_rdf": validate_list(v.validated_model(TripleFragmentBase)),
+            "measure_uri": v.uri,
+            "arbitrary_rdf": v.list(v.validated_model(TripleFragmentBase)),
         }
 
 
@@ -111,10 +105,10 @@ class NewQbMeasure(QbMeasure, UriIdentifiable):
     def _get_validations(self) -> Dict[str, ValidationFunction]:
 
         return {
-            "label": validate_str_type,
-            "description": validate_optional(validate_str_type),
-            "parent_measure_uri": validate_optional(validate_uri),
-            "source_uri": validate_optional(validate_uri),
+            "label": v.string,
+            "description": v.optional(v.string),
+            "parent_measure_uri": v.optional(v.uri),
+            "source_uri": v.optional(v.uri),
             **UriIdentifiable._get_validations(self),
-            "arbitrary_rdf": validate_list(v.validated_model(TripleFragmentBase)),
+            "arbitrary_rdf": v.list(v.validated_model(TripleFragmentBase)),
         }

--- a/src/csvcubed/models/cube/qb/components/measuresdimension.py
+++ b/src/csvcubed/models/cube/qb/components/measuresdimension.py
@@ -16,7 +16,7 @@ from csvcubed.inputs import PandasDataTypes, pandas_input_to_columnar_str
 from csvcubed.models.validationerror import ValidationError
 from csvcubed.utils import validations as v
 from csvcubed.utils.qb.validation.uri_safe import ensure_no_uri_safe_conflicts
-from csvcubed.utils.validations import ValidationFunction, validate_list
+from csvcubed.utils.validations import ValidationFunction
 
 from .datastructuredefinition import QbColumnStructuralDefinition
 from .measure import ExistingQbMeasure, NewQbMeasure, QbMeasure
@@ -117,4 +117,4 @@ class QbMultiMeasureDimension(QbColumnStructuralDefinition):
         return []
 
     def _get_validations(self) -> Dict[str, ValidationFunction]:
-        return {"measures": validate_list(v.validated_model(QbMeasure))}
+        return {"measures": v.list(v.validated_model(QbMeasure))}

--- a/src/csvcubed/models/cube/qb/components/observedvalue.py
+++ b/src/csvcubed/models/cube/qb/components/observedvalue.py
@@ -12,7 +12,6 @@ import pandas as pd
 from csvcubed.models.validatedmodel import ValidationFunction
 from csvcubed.models.validationerror import ValidationError
 from csvcubed.utils import validations as v
-from csvcubed.utils.validations import validate_optional, validate_uri
 
 from .datastructuredefinition import QbColumnStructuralDefinition
 from .measure import QbMeasure
@@ -49,7 +48,7 @@ class QbObservationValue(QbColumnStructuralDefinition):
 
     def _get_validations(self) -> Dict[str, ValidationFunction]:
         return {
-            "measure": validate_optional(v.validated_model(QbMeasure)),
-            "unit": validate_optional(v.validated_model(QbUnit)),
-            "data_type": v.any_of(v.data_type, validate_uri),
+            "measure": v.optional(v.validated_model(QbMeasure)),
+            "unit": v.optional(v.validated_model(QbUnit)),
+            "data_type": v.any_of(v.data_type, v.uri),
         }

--- a/src/csvcubed/models/cube/qb/components/unit.py
+++ b/src/csvcubed/models/cube/qb/components/unit.py
@@ -131,9 +131,9 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
                 '{unit.base_unit_scaling_factor}' has been specified, but the following is missing and must be
                         provided: '{unit.base_unit}'.
                         """,
-                    property_path=[],
+                    property_path=["Whole Object"],
                     # TODO: what is the property path here?
-                    offending_value="Whole Object",
+                    offending_value=unit.base_unit,
                 )
             )
 
@@ -147,9 +147,9 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
                 '{unit.si_base_unit_conversion_multiplier}' has been specified, but the following is missing and must be
                         provided: '{unit.qudt_quantity_kind_uri}'.
                         """,
-                    property_path=[],
+                    property_path=["Whole Object"],
                     # TODO: what is the property path here?
-                    offending_value="Whole Object",
+                    offending_value=unit.qudt_quantity_kind_uri,
                 )
             )
         return errors

--- a/src/csvcubed/models/cube/qb/components/unit.py
+++ b/src/csvcubed/models/cube/qb/components/unit.py
@@ -38,7 +38,6 @@ class ExistingQbUnit(QbUnit):
     unit_uri: str
 
     _unit_uri_validator = pydantic_validate_uri("unit_uri")
-    # TODO: ^ Does this need replacing in this ticket (676)?
 
     def __eq__(self, other):
         return isinstance(other, ExistingQbUnit) and other.unit_uri == self.unit_uri
@@ -112,7 +111,7 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
 
     @staticmethod
     def _validation_base_unit_scaling_factor_dependency(
-        unit: "NewQbUnit",
+        unit: "NewQbUnit", property_path: List[str]
     ) -> List[ValidateModelPropertiesError]:
         errors: List[ValidateModelPropertiesError] = []
 
@@ -120,9 +119,8 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
             errors.append(
                 ValidateModelPropertiesError(
                     f"A value for base unit scaling factor has been specified: '{unit.base_unit_scaling_factor}' but no value for base unit has been specified and must be provided.",
-                    property_path=["Whole Object"],
-                    # TODO: what is the property path here?
-                    offending_value=unit.base_unit,
+                    property_path,
+                    unit,
                 )
             )
 
@@ -132,10 +130,9 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
         ):
             errors.append(
                 ValidateModelPropertiesError(
-                    f"A value for si base unit conversion multiplier has been specified: '{unit.si_base_unit_conversion_multiplier}' but no value for qudt quantity kind url has been specified and must be provided.",
-                    property_path=["Whole Object"],
-                    # TODO: what is the property path here?
-                    offending_value=unit.qudt_quantity_kind_uri,
+                    f"A value for si base unit conversion multiplier has been specified: '{unit.si_base_unit_conversion_multiplier}' but no value for QUDT quantity kind URL has been specified and must be provided.",
+                    property_path,
+                    unit,
                 )
             )
         return errors

--- a/src/csvcubed/models/cube/qb/components/unit.py
+++ b/src/csvcubed/models/cube/qb/components/unit.py
@@ -131,7 +131,9 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
                 '{unit.base_unit_scaling_factor}' has been specified, but the following is missing and must be
                         provided: '{unit.base_unit}'.
                         """,
-                    "Whole Object",
+                    property_path=[],
+                    # TODO: what is the property path here?
+                    offending_value="Whole Object",
                 )
             )
 
@@ -145,7 +147,9 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
                 '{unit.si_base_unit_conversion_multiplier}' has been specified, but the following is missing and must be
                         provided: '{unit.qudt_quantity_kind_uri}'.
                         """,
-                    "Whole Object",
+                    property_path=[],
+                    # TODO: what is the property path here?
+                    offending_value="Whole Object",
                 )
             )
         return errors

--- a/src/csvcubed/models/cube/qb/components/unit.py
+++ b/src/csvcubed/models/cube/qb/components/unit.py
@@ -17,13 +17,6 @@ from csvcubed.models.validatedmodel import (
 )
 from csvcubed.models.validationerror import ValidateModelPropertiesError
 from csvcubed.utils import validations as v
-from csvcubed.utils.validations import (
-    validate_float_type,
-    validate_list,
-    validate_optional,
-    validate_str_type,
-    validate_uri,
-)
 from csvcubed.utils.validators.attributes import (
     enforce_optional_attribute_dependencies as pydantic_enforce_optional_attribute_dependencies,
 )
@@ -45,6 +38,7 @@ class ExistingQbUnit(QbUnit):
     unit_uri: str
 
     _unit_uri_validator = pydantic_validate_uri("unit_uri")
+    # TODO: ^ Does this need replacing in this ticket (676)?
 
     def __eq__(self, other):
         return isinstance(other, ExistingQbUnit) and other.unit_uri == self.unit_uri
@@ -53,7 +47,7 @@ class ExistingQbUnit(QbUnit):
         return self.unit_uri.__hash__()
 
     def _get_validations(self) -> Union[Validations, Dict[str, ValidationFunction]]:
-        return {"unit_uri": validate_uri}
+        return {"unit_uri": v.uri}
 
 
 @dataclass
@@ -101,17 +95,15 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
     def _get_validations(self) -> Union[Validations, Dict[str, ValidationFunction]]:
         return Validations(
             individual_property_validations={
-                "label": validate_str_type,
-                "description": validate_optional(validate_str_type),
-                "source_uri": validate_optional(validate_uri),
+                "label": v.string,
+                "description": v.optional(v.string),
+                "source_uri": v.optional(v.uri),
                 **UriIdentifiable._get_validations(self),
-                "arbitrary_rdf": validate_list(v.validated_model(TripleFragmentBase)),
-                "base_unit": validate_optional(v.validated_model(QbUnit)),
-                "base_unit_scaling_factor": validate_optional(validate_float_type),
-                "qudt_quantity_kind_uri": validate_optional(validate_uri),
-                "si_base_unit_conversion_multiplier": validate_optional(
-                    validate_float_type
-                ),
+                "arbitrary_rdf": v.list(v.validated_model(TripleFragmentBase)),
+                "base_unit": v.optional(v.validated_model(QbUnit)),
+                "base_unit_scaling_factor": v.optional(v.float),
+                "qudt_quantity_kind_uri": v.optional(v.uri),
+                "si_base_unit_conversion_multiplier": v.optional(v.float),
             },
             whole_object_validations=[
                 self._validation_base_unit_scaling_factor_dependency

--- a/src/csvcubed/models/cube/qb/components/unit.py
+++ b/src/csvcubed/models/cube/qb/components/unit.py
@@ -127,10 +127,7 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
         if unit.base_unit_scaling_factor is not None and unit.base_unit is None:
             errors.append(
                 ValidateModelPropertiesError(
-                    f"""
-                '{unit.base_unit_scaling_factor}' has been specified, but the following is missing and must be
-                        provided: '{unit.base_unit}'.
-                        """,
+                    f"A value for base unit scaling factor has been specified: '{unit.base_unit_scaling_factor}' but no value for base unit has been specified and must be provided.",
                     property_path=["Whole Object"],
                     # TODO: what is the property path here?
                     offending_value=unit.base_unit,
@@ -143,10 +140,7 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
         ):
             errors.append(
                 ValidateModelPropertiesError(
-                    f"""
-                '{unit.si_base_unit_conversion_multiplier}' has been specified, but the following is missing and must be
-                        provided: '{unit.qudt_quantity_kind_uri}'.
-                        """,
+                    f"A value for si base unit conversion multiplier has been specified: '{unit.si_base_unit_conversion_multiplier}' but no value for qudt quantity kind url has been specified and must be provided.",
                     property_path=["Whole Object"],
                     # TODO: what is the property path here?
                     offending_value=unit.qudt_quantity_kind_uri,

--- a/src/csvcubed/models/cube/qb/components/unitscolumn.py
+++ b/src/csvcubed/models/cube/qb/components/unitscolumn.py
@@ -17,11 +17,6 @@ from csvcubed.models.validatedmodel import ValidationFunction
 from csvcubed.models.validationerror import ValidationError
 from csvcubed.utils import validations as v
 from csvcubed.utils.qb.validation.uri_safe import ensure_no_uri_safe_conflicts
-from csvcubed.utils.validations import (
-    validate_list,
-    validate_optional,
-    validate_str_type,
-)
 
 from .datastructuredefinition import QbColumnStructuralDefinition
 from .unit import ExistingQbUnit, NewQbUnit, QbUnit
@@ -135,6 +130,6 @@ class QbMultiUnits(QbColumnStructuralDefinition):
 
     def _get_validations(self) -> Dict[str, ValidationFunction]:
         return {
-            "units": validate_list(v.validated_model(QbUnit)),
-            "observed_value_col_title": validate_optional(validate_str_type),
+            "units": v.list(v.validated_model(QbUnit)),
+            "observed_value_col_title": v.optional(v.string),
         }

--- a/src/csvcubed/models/uriidentifiable.py
+++ b/src/csvcubed/models/uriidentifiable.py
@@ -8,8 +8,8 @@ from abc import ABC, abstractmethod
 from typing import Dict, Optional
 
 from csvcubed.models.validatedmodel import ValidationFunction
+from csvcubed.utils import validations as v
 from csvcubed.utils.uri import uri_safe
-from csvcubed.utils.validations import validate_optional, validate_str_type
 
 
 @dataclasses.dataclass
@@ -50,4 +50,4 @@ class UriIdentifiable(ABC):
         self.uri_safe_identifier_override = uri_safe_identifier
 
     def _get_validations(self) -> Dict[str, ValidationFunction]:
-        return {"uri_safe_identifier_override": validate_optional(validate_str_type)}
+        return {"uri_safe_identifier_override": v.optional(v.string)}

--- a/src/csvcubed/models/validatedmodel.py
+++ b/src/csvcubed/models/validatedmodel.py
@@ -32,7 +32,9 @@ class ValidatedModel(DataClassBase):
     The class will run a valdiation function for each attribute that is passed in and return either a list of errors or an emtpy list.
     """
 
-    def validate(self) -> List[ValidateModelPropertiesError]:
+    def validate(
+        self, property_path: List[str] = []
+    ) -> List[ValidateModelPropertiesError]:
         """
         The validate function will go through each attribute and the corresponding validation function and
          collect the validation errors(if there is any) and return the variable names and the error messages.
@@ -54,18 +56,21 @@ class ValidatedModel(DataClassBase):
         return validation_errors
 
     def _apply_individual_property_validations(
-        self, individual_property_validations: Dict[str, ValidationFunction]
+        self,
+        individual_property_validations: Dict[str, ValidationFunction],
+        property_path: List[str],
     ) -> List[ValidateModelPropertiesError]:
         validation_errors: List[ValidateModelPropertiesError] = []
 
         for (
-            property_path,
+            property_name,
             validation_function,
         ) in individual_property_validations.items():
+            new_property_path = [*property_path, property_name]
             logging.debug("Validating %s", property_path)
 
-            property_value = getattr(self, property_path)
-            errs = validation_function(property_value, property_path)
+            property_value = getattr(self, property_name)
+            errs = validation_function(property_value, new_property_path)
 
             if any(errs):
                 logging.debug("'%s' generated errors: %s", property_path, errs)

--- a/src/csvcubed/models/validatedmodel.py
+++ b/src/csvcubed/models/validatedmodel.py
@@ -76,6 +76,7 @@ class ValidatedModel(DataClassBase):
                 logging.debug("'%s' generated errors: %s", property_name, errs)
 
             validation_errors += errs
+            property_path = []
 
         return validation_errors
 

--- a/src/csvcubed/models/validatedmodel.py
+++ b/src/csvcubed/models/validatedmodel.py
@@ -70,7 +70,7 @@ class ValidatedModel(DataClassBase):
             logging.debug("Validating %s", property_name)
 
             property_value = getattr(self, property_name)
-            errs = validation_function(property_value, property_name, property_path)
+            errs = validation_function(property_value, property_path)
 
             if any(errs):
                 logging.debug("'%s' generated errors: %s", property_name, errs)

--- a/src/csvcubed/models/validatedmodel.py
+++ b/src/csvcubed/models/validatedmodel.py
@@ -29,7 +29,7 @@ class Validations(Generic[T]):
 @dataclass
 class ValidatedModel(DataClassBase):
     """This abstract class that will act as a parent class for class attribute validations.
-    The class will run a valdiation function for each attribute that is passed in and return either a list of errors or an emtpy list.
+    The class will run a valdiation function for each attribute that is passed in and return either a list of errors or an empty list.
     """
 
     def validate(

--- a/src/csvcubed/models/validatedmodel.py
+++ b/src/csvcubed/models/validatedmodel.py
@@ -28,8 +28,8 @@ class Validations(Generic[T]):
 
 @dataclass
 class ValidatedModel(DataClassBase):
-    """This abrstract class that will act as a parent class for class attribute validations.
-    The class will run a valdiation function for each attribute that is passed in and return either a list of errors or an emtpry list.
+    """This abstract class that will act as a parent class for class attribute validations.
+    The class will run a valdiation function for each attribute that is passed in and return either a list of errors or an emtpy list.
     """
 
     def validate(self) -> List[ValidateModelPropertiesError]:
@@ -59,16 +59,17 @@ class ValidatedModel(DataClassBase):
         validation_errors: List[ValidateModelPropertiesError] = []
 
         for (
-            property_name,
+            property_path,
             validation_function,
         ) in individual_property_validations.items():
-            logging.debug("Validating %s", property_name)
+            logging.debug("Validating %s", property_path)
 
-            property_value = getattr(self, property_name)
-            errs = validation_function(property_value, property_name)
+            property_value = getattr(self, property_path)
+            errs = validation_function(property_value, property_path)
 
             if any(errs):
-                logging.debug("'%s' generated errors: %s", property_name, errs)
+                logging.debug("'%s' generated errors: %s", property_path, errs)
+                # I think this is where we add the message about offending value.
 
             validation_errors += errs
 

--- a/src/csvcubed/models/validationerror.py
+++ b/src/csvcubed/models/validationerror.py
@@ -71,3 +71,9 @@ class ValidateModelPropertiesError(ValidationError):
 
     property_path: List[str]
     offending_value: Any
+
+    def __post_init__(self):
+        self.message = (
+            self.message
+            + f" Check the following variable at the property path: '{self.property_path}'"
+        )

--- a/src/csvcubed/models/validationerror.py
+++ b/src/csvcubed/models/validationerror.py
@@ -73,7 +73,4 @@ class ValidateModelPropertiesError(ValidationError):
     offending_value: Any
 
     def __post_init__(self):
-        self.message = (
-            self.message
-            + f" Check the following variable at the property path: '{self.property_path}'"
-        )
+        self.message += f" Check the following variable at the property path: '{self.property_path}'"

--- a/src/csvcubed/models/validationerror.py
+++ b/src/csvcubed/models/validationerror.py
@@ -69,4 +69,5 @@ class ValidateModelPropertiesError(ValidationError):
     This error will be returned with the name of the variable that has not been validated.
     """
 
-    property_name: str
+    # property_name: str
+    property_path: List[str]

--- a/src/csvcubed/models/validationerror.py
+++ b/src/csvcubed/models/validationerror.py
@@ -69,5 +69,6 @@ class ValidateModelPropertiesError(ValidationError):
     This error will be returned with the name of the variable that has not been validated.
     """
 
-    # property_name: str
+    property_name: str
     property_path: List[str]
+    # offending_value: str

--- a/src/csvcubed/models/validationerror.py
+++ b/src/csvcubed/models/validationerror.py
@@ -4,7 +4,7 @@ ValidationError
 """
 from abc import ABC
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from csvcubedmodels.dataclassbase import DataClassBase
 
@@ -69,6 +69,5 @@ class ValidateModelPropertiesError(ValidationError):
     This error will be returned with the name of the variable that has not been validated.
     """
 
-    property_name: str
     property_path: List[str]
-    # offending_value: str
+    offending_value: Any

--- a/src/csvcubed/utils/validations.py
+++ b/src/csvcubed/utils/validations.py
@@ -42,7 +42,7 @@ def validate_list(
 
 
 def validate_str_type(
-    value: str, property_name: str
+    value: str, property_name: str, property_path: List[str]
 ) -> List[ValidateModelPropertiesError]:
     """
     This function will validate if the argument provided is in fact a string type and,
@@ -53,6 +53,7 @@ def validate_str_type(
             ValidateModelPropertiesError(
                 "This variable should be a string value, check the following variable:",
                 property_name,
+                property_path,
             )
         ]
 
@@ -121,12 +122,12 @@ def validate_optional(
     """
 
     def _validate(
-        maybe_item: Optional[T], property_name: str
+        maybe_item: Optional[T], property_name: str, property_path: List[str]
     ) -> List[ValidateModelPropertiesError]:
         if maybe_item is None:
             return []
 
-        return validate_item(maybe_item, property_name)
+        return validate_item(maybe_item, property_name, property_path)
 
     return _validate
 
@@ -266,7 +267,7 @@ def validated_model(validated_model_type: Type[ValidatedModel]):
         )
 
     def validate(
-        value: ValidatedModel, property_name: str
+        value: ValidatedModel, property_name: str, property_path: List[str]
     ) -> List[ValidateModelPropertiesError]:
         if not isinstance(value, validated_model_type):
             # This error occurs when runtime validation occurs.
@@ -277,7 +278,7 @@ def validated_model(validated_model_type: Type[ValidatedModel]):
                 )
             ]
 
-        return value.validate()
+        return value.validate(property_path=property_path)
 
     return validate
 

--- a/src/csvcubed/utils/validations.py
+++ b/src/csvcubed/utils/validations.py
@@ -29,7 +29,7 @@ def list(
         if not isinstance(list_items, builtins.list):
             return [
                 ValidateModelPropertiesError(
-                    f"The value '{truncate(str(list_items), 50)}' should be a list. Check the following variable at the property path: '{property_path}'",
+                    f"The value '{truncate(str(list_items), 50)}' should be a list.",
                     property_path,
                     list_items,
                 )
@@ -52,7 +52,7 @@ def string(value: str, property_path: List[str]) -> List[ValidateModelProperties
     if not isinstance(value, str):
         return [
             ValidateModelPropertiesError(
-                f"The value '{truncate(str(value), 50)}' should be a string. Check the following variable at the property path: '{property_path}'",
+                f"The value '{truncate(str(value), 50)}' should be a string.",
                 property_path,
                 value,
             )
@@ -73,7 +73,7 @@ def uri(value: str, property_path: List[str]) -> List[ValidateModelPropertiesErr
     if not looks_like_uri(value):
         return [
             ValidateModelPropertiesError(
-                f"The value '{truncate(str(value), 50)}' should be a URI. Check the following variable at the property path: '{property_path}'",
+                f"The value '{truncate(str(value), 50)}' should be a URI.",
                 property_path,
                 value,
             )
@@ -90,7 +90,7 @@ def integer(value: int, property_path: List[str]) -> List[ValidateModelPropertie
     if isinstance(value, bool) or not isinstance(value, int):
         return [
             ValidateModelPropertiesError(
-                f"The value '{truncate(str(value), 50)}' should be an integer. Check the following variable at the property path: '{property_path}'",
+                f"The value '{truncate(str(value), 50)}' should be an integer.",
                 property_path,
                 value,
             )
@@ -109,7 +109,7 @@ def boolean(
     if not isinstance(value, bool):
         return [
             ValidateModelPropertiesError(
-                f"This value '{truncate(str(value), 50)}' should be a boolean value. Check the following variable at the property path: '{property_path}'",
+                f"This value '{truncate(str(value), 50)}' should be a boolean value.",
                 property_path,
                 value,
             )
@@ -147,7 +147,7 @@ def float(
     if not isinstance(value, builtins.float):
         return [
             ValidateModelPropertiesError(
-                f"The value '{truncate(str(value), 50)}' should be a float. Check the following variable at the property path: '{property_path}'",
+                f"The value '{truncate(str(value), 50)}' should be a float.",
                 property_path,
                 value,
             )
@@ -155,7 +155,7 @@ def float(
     elif isnan(value):
         return [
             ValidateModelPropertiesError(
-                f"The value '{truncate(str(value), 50)}' should be a float but is Not a Number (NaN). Check the following variable at the property path: '{property_path}'",
+                f"The value should be a float but is Not a Number (NaN).",
                 property_path,
                 value,
             )
@@ -163,7 +163,7 @@ def float(
     elif isinf(value):
         return [
             ValidateModelPropertiesError(
-                f"The value '{truncate(str(value), 50)}' should be a float but is +-infinity. Check the following variable at the property path: '{property_path}'",
+                f"The value should be a float but is +-infinity.",
                 property_path,
                 value,
             )
@@ -181,7 +181,7 @@ def file(value: Path, property_path: List[str]) -> List[ValidateModelPropertiesE
         if not value.exists():
             return [
                 ValidateModelPropertiesError(
-                    f"The file '{truncate(str(value), 50)}' does not exist. Check the following variable at the property path: '{property_path}'",
+                    f"The file '{truncate(str(value), 50)}' does not exist.",
                     property_path,
                     value,
                 )
@@ -191,7 +191,7 @@ def file(value: Path, property_path: List[str]) -> List[ValidateModelPropertiesE
     else:
         return [
             ValidateModelPropertiesError(
-                f"The file '{truncate(str(value), 50)}' is not a valid file path. Check the following variable at the property path: '{property_path}'",
+                f"The file '{truncate(str(value), 50)}' is not a valid file path.",
                 property_path,
                 value,
             )
@@ -216,7 +216,7 @@ def any_of(*conditions: ValidationFunction) -> ValidationFunction:
 
         return [
             ValidateModelPropertiesError(
-                f"The value '{truncate(str(value), 50)}' does not satisfy any single condition for variable at the property path: '{property_path}'",
+                f"The value '{truncate(str(value), 50)}' does not satisfy any single condition for the variable.",
                 property_path,
                 value,
             ),
@@ -241,7 +241,7 @@ def enum(enum_type: Type[Enum]) -> ValidationFunction:
 
         return [
             ValidateModelPropertiesError(
-                f"Could not find matching enum value for '{truncate(str(value), 50)}' in {enum_type.__name__} at property path: {property_path}",
+                f"Could not find matching enum value for '{truncate(str(value), 50)}' in {enum_type.__name__}.",
                 property_path,
                 value,
             )
@@ -260,7 +260,7 @@ def data_type(
     if data_type not in ACCEPTED_DATATYPE_MAPPING.keys():
         return [
             ValidateModelPropertiesError(
-                f"'{truncate(str(data_type), 50)}' is not recognised as a valid data type. Check the following variable at the property path: '{property_path}'",
+                f"'{truncate(str(data_type), 50)}' is not recognised as a valid data type.",
                 property_path,
                 data_type,
             )
@@ -290,7 +290,7 @@ def validated_model(validated_model_type: Type[ValidatedModel]):
             # This error occurs when runtime validation occurs.
             return [
                 ValidateModelPropertiesError(
-                    f"Value '{truncate(str(value), 50)}' was not an instance of the expected type '{validated_model_type.__name__}'. Check the following variable at the property path: '{property_path}'",
+                    f"Value '{truncate(str(value), 50)}' was not an instance of the expected type '{validated_model_type.__name__}'.",
                     property_path,
                     value,
                 )
@@ -314,7 +314,7 @@ def is_instance_of(expect_instance_type: Type[object]) -> ValidationFunction:
         if not isinstance(value, expect_instance_type):
             return [
                 ValidateModelPropertiesError(
-                    f"Value '{truncate(str(value), 50)}' was not an instance of the expected type '{expect_instance_type.__name__}'. Check the following variable at the property path: '{property_path}'",
+                    f"Value '{truncate(str(value), 50)}' was not an instance of the expected type '{expect_instance_type.__name__}'.",
                     property_path,
                     value,
                 ),

--- a/src/csvcubed/utils/validations.py
+++ b/src/csvcubed/utils/validations.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, List, Optional, Type, TypeVar
 from csvcubed.models.cube.qb.components.constants import ACCEPTED_DATATYPE_MAPPING
 from csvcubed.models.validatedmodel import ValidatedModel, ValidationFunction
 from csvcubed.models.validationerror import ValidateModelPropertiesError
+from csvcubed.utils.text import truncate
 from csvcubed.utils.uri import looks_like_uri
 
 T = TypeVar("T")
@@ -27,7 +28,7 @@ def validate_list(
         if not isinstance(list_items, list):
             return [
                 ValidateModelPropertiesError(
-                    f"The value '{list_items}' should be a list. Check the following variable at the property path: '{property_path}'",
+                    f"The value '{truncate(str(list_items), 50)}' should be a list. Check the following variable at the property path: '{property_path}'",
                     property_path,
                     list_items,
                 )
@@ -52,7 +53,7 @@ def validate_str_type(
     if not isinstance(value, str):
         return [
             ValidateModelPropertiesError(
-                f"The value '{value}' should be a string. Check the following variable at the property path: '{property_path}'",
+                f"The value '{truncate(str(value), 50)}' should be a string. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -75,7 +76,7 @@ def validate_uri(
     if not looks_like_uri(value):
         return [
             ValidateModelPropertiesError(
-                f"The value '{value}' should be a URI. Check the following variable at the property path: '{property_path}'",
+                f"The value '{truncate(str(value), 50)}' should be a URI. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -94,7 +95,7 @@ def validate_int_type(
     if isinstance(value, bool) or not isinstance(value, int):
         return [
             ValidateModelPropertiesError(
-                f"The value '{value}' should be an integer. Check the following variable at the property path: '{property_path}'",
+                f"The value '{truncate(str(value), 50)}' should be an integer. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -113,7 +114,7 @@ def boolean(
     if not isinstance(value, bool):
         return [
             ValidateModelPropertiesError(
-                f"This value '{value}' should be a boolean value. Check the following variable at the property path: '{property_path}'",
+                f"This value '{truncate(str(value), 50)}' should be a boolean value. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -151,7 +152,7 @@ def validate_float_type(
     if not isinstance(value, float):
         return [
             ValidateModelPropertiesError(
-                f"The value '{value}' should be a float. Check the following variable at the property path: '{property_path}'",
+                f"The value '{truncate(str(value), 50)}' should be a float. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -159,7 +160,7 @@ def validate_float_type(
     elif isnan(value):
         return [
             ValidateModelPropertiesError(
-                f"The value '{value}' should be a float but is Not a Number (NaN). Check the following variable at the property path: '{property_path}'",
+                f"The value '{truncate(str(value), 50)}' should be a float but is Not a Number (NaN). Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -167,7 +168,7 @@ def validate_float_type(
     elif isinf(value):
         return [
             ValidateModelPropertiesError(
-                f"The value '{value}' should be a float but is +-infinity. Check the following variable at the property path: '{property_path}'",
+                f"The value '{truncate(str(value), 50)}' should be a float but is +-infinity. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -187,7 +188,7 @@ def validate_file(
         if not value.exists():
             return [
                 ValidateModelPropertiesError(
-                    f"The file '{value}' does not exist. Check the following variable at the property path: '{property_path}'",
+                    f"The file '{truncate(str(value), 50)}' does not exist. Check the following variable at the property path: '{property_path}'",
                     property_path,
                     value,
                 )
@@ -197,7 +198,7 @@ def validate_file(
     else:
         return [
             ValidateModelPropertiesError(
-                f"The file '{value}' is not a valid file path. Check the following variable at the property path: '{property_path}'",
+                f"The file '{truncate(str(value), 50)}' is not a valid file path. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -222,7 +223,7 @@ def any_of(*conditions: ValidationFunction) -> ValidationFunction:
 
         return [
             ValidateModelPropertiesError(
-                f"The value '{value}' does not satisfy any single condition for variable at the property path: '{property_path}'",
+                f"The value '{truncate(str(value), 50)}' does not satisfy any single condition for variable at the property path: '{property_path}'",
                 property_path,
                 value,
             ),
@@ -247,7 +248,7 @@ def enum(enum_type: Type[Enum]) -> ValidationFunction:
 
         return [
             ValidateModelPropertiesError(
-                f"Could not find matching enum value for '{value}' in {enum_type.__name__} at property path: {property_path}",
+                f"Could not find matching enum value for '{truncate(str(value), 50)}' in {enum_type.__name__} at property path: {property_path}",
                 property_path,
                 value,
             )
@@ -266,7 +267,7 @@ def data_type(
     if data_type not in ACCEPTED_DATATYPE_MAPPING.keys():
         return [
             ValidateModelPropertiesError(
-                f"'{data_type}' is not recognised as a valid data type. Check the following variable at the property path: '{property_path}'",
+                f"'{truncate(str(data_type), 50)}' is not recognised as a valid data type. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 data_type,
             )
@@ -296,7 +297,7 @@ def validated_model(validated_model_type: Type[ValidatedModel]):
             # This error occurs when runtime validation occurs.
             return [
                 ValidateModelPropertiesError(
-                    f"Value '{value}' was not an instance of the expected type '{validated_model_type.__name__}'. Check the following variable at the property path: '{property_path}'",
+                    f"Value '{truncate(str(value), 50)}' was not an instance of the expected type '{validated_model_type.__name__}'. Check the following variable at the property path: '{property_path}'",
                     property_path,
                     value,
                 )
@@ -320,7 +321,7 @@ def is_instance_of(expect_instance_type: Type[object]) -> ValidationFunction:
         if not isinstance(value, expect_instance_type):
             return [
                 ValidateModelPropertiesError(
-                    f"Value '{value}' was not an instance of the expected type '{expect_instance_type.__name__}'. Check the following variable at the property path: '{property_path}'",
+                    f"Value '{truncate(str(value), 50)}' was not an instance of the expected type '{expect_instance_type.__name__}'. Check the following variable at the property path: '{property_path}'",
                     property_path,
                     value,
                 ),

--- a/src/csvcubed/utils/validations.py
+++ b/src/csvcubed/utils/validations.py
@@ -155,7 +155,7 @@ def float(
     elif isnan(value):
         return [
             ValidateModelPropertiesError(
-                f"The value should be a float but is Not a Number (NaN).",
+                "The value should be a float but is Not a Number (NaN).",
                 property_path,
                 value,
             )
@@ -163,7 +163,7 @@ def float(
     elif isinf(value):
         return [
             ValidateModelPropertiesError(
-                f"The value should be a float but is +-infinity.",
+                "The value should be a float but is +-infinity.",
                 property_path,
                 value,
             )

--- a/src/csvcubed/utils/validations.py
+++ b/src/csvcubed/utils/validations.py
@@ -1,4 +1,5 @@
 # This script contain a set of function that can be used to validate specific class attributes/ member variables
+import builtins
 import datetime as dt
 from enum import Enum
 from math import isinf, isnan
@@ -14,7 +15,7 @@ from csvcubed.utils.uri import looks_like_uri
 T = TypeVar("T")
 
 
-def validate_list(
+def list(
     validate_list_item: Callable[[T, str], List[ValidateModelPropertiesError]],
 ) -> Callable[[List[T], str], List[ValidateModelPropertiesError]]:
     """
@@ -25,7 +26,7 @@ def validate_list(
     def _validate(
         list_items: List[T], property_path: List[str]
     ) -> List[ValidateModelPropertiesError]:
-        if not isinstance(list_items, list):
+        if not isinstance(list_items, builtins.list):
             return [
                 ValidateModelPropertiesError(
                     f"The value '{truncate(str(list_items), 50)}' should be a list. Check the following variable at the property path: '{property_path}'",
@@ -43,9 +44,7 @@ def validate_list(
     return _validate
 
 
-def validate_str_type(
-    value: str, property_path: List[str]
-) -> List[ValidateModelPropertiesError]:
+def string(value: str, property_path: List[str]) -> List[ValidateModelPropertiesError]:
     """
     This function will validate if the argument provided is in fact a string type and,
     returns any errors returned by the item validation function.
@@ -62,14 +61,12 @@ def validate_str_type(
     return []
 
 
-def validate_uri(
-    value: str, property_path: List[str]
-) -> List[ValidateModelPropertiesError]:
+def uri(value: str, property_path: List[str]) -> List[ValidateModelPropertiesError]:
     """
     This function will validate if the argument provided is in fact a string type and,
     check is the string contains a uri. Either checks fail it returns any errors returned by the item validation function.
     """
-    errors = validate_str_type(value, property_path)
+    errors = string(value, property_path)
     if any(errors):
         return errors
 
@@ -85,9 +82,7 @@ def validate_uri(
     return []
 
 
-def validate_int_type(
-    value: int, property_path: List[str]
-) -> List[ValidateModelPropertiesError]:
+def integer(value: int, property_path: List[str]) -> List[ValidateModelPropertiesError]:
     """
     This function will validate if the argument provided is in fact a integer type and,
     returns any errors returned by the item validation function.
@@ -123,7 +118,7 @@ def boolean(
     return []
 
 
-def validate_optional(
+def optional(
     validate_item: Callable[[T, str], List[ValidateModelPropertiesError]]
 ) -> Callable[[Optional[T], str], List[ValidateModelPropertiesError]]:
     """
@@ -142,14 +137,12 @@ def validate_optional(
     return _validate
 
 
-def validate_float_type(
-    value: float, property_path: List[str]
-) -> List[ValidateModelPropertiesError]:
+def float(value: float, property_path: List[str]) -> List[ValidateModelPropertiesError]:
     """
     This function will validate if the argument provided is in fact a float type and,
     returns any errors returned by the item validation function.
     """
-    if not isinstance(value, float):
+    if not isinstance(value, builtins.float):
         return [
             ValidateModelPropertiesError(
                 f"The value '{truncate(str(value), 50)}' should be a float. Check the following variable at the property path: '{property_path}'",
@@ -177,9 +170,7 @@ def validate_float_type(
     return []
 
 
-def validate_file(
-    value: Path, property_path: List[str]
-) -> List[ValidateModelPropertiesError]:
+def file(value: Path, property_path: List[str]) -> List[ValidateModelPropertiesError]:
     """
     This function validates whether the given argument is in fact of type Path, and if not,
     returns any validation errors raised by the validation function.

--- a/src/csvcubed/utils/validations.py
+++ b/src/csvcubed/utils/validations.py
@@ -16,8 +16,8 @@ T = TypeVar("T")
 
 
 def list(
-    validate_list_item: Callable[[T, str], List[ValidateModelPropertiesError]],
-) -> Callable[[List[T], str], List[ValidateModelPropertiesError]]:
+    validate_list_item: Callable[[T, List[str]], List[ValidateModelPropertiesError]],
+) -> Callable[[List[T], List[str]], List[ValidateModelPropertiesError]]:
     """
     This function will validate if the argument provided is in fact a list and,
     in a loop will check each member of the list and returns any errors returned by the item validation function.
@@ -37,8 +37,8 @@ def list(
 
         return [
             err
-            for list_item in list_items
-            for err in validate_list_item(list_item, property_path)
+            for i, list_item in enumerate(list_items)
+            for err in validate_list_item(list_item, [*property_path, str(i)])
         ]
 
     return _validate
@@ -119,8 +119,8 @@ def boolean(
 
 
 def optional(
-    validate_item: Callable[[T, str], List[ValidateModelPropertiesError]]
-) -> Callable[[Optional[T], str], List[ValidateModelPropertiesError]]:
+    validate_item: Callable[[T, List[str]], List[ValidateModelPropertiesError]]
+) -> Callable[[Optional[T], List[str]], List[ValidateModelPropertiesError]]:
     """
     This function will validate if the Optional argument provided is a None value it will return an empty list,
     else it returns any errors returned by the item validation function .
@@ -137,7 +137,9 @@ def optional(
     return _validate
 
 
-def float(value: float, property_path: List[str]) -> List[ValidateModelPropertiesError]:
+def float(
+    value: builtins.float, property_path: List[str]
+) -> List[ValidateModelPropertiesError]:
     """
     This function will validate if the argument provided is in fact a float type and,
     returns any errors returned by the item validation function.

--- a/src/csvcubed/utils/validations.py
+++ b/src/csvcubed/utils/validations.py
@@ -163,7 +163,7 @@ def float(
     elif isinf(value):
         return [
             ValidateModelPropertiesError(
-                "The value should be a float but is +-infinity.",
+                "The value should be a float but is ±infinity.",
                 property_path,
                 value,
             )

--- a/src/csvcubed/utils/validations.py
+++ b/src/csvcubed/utils/validations.py
@@ -27,7 +27,7 @@ def validate_list(
         if not isinstance(list_items, list):
             return [
                 ValidateModelPropertiesError(
-                    f"This variable should be a list, check the following variable:",
+                    f"The value '{list_items}' should be a list. Check the following variable at the property path: '{property_path}'",
                     property_path,
                     list_items,
                 )
@@ -52,7 +52,7 @@ def validate_str_type(
     if not isinstance(value, str):
         return [
             ValidateModelPropertiesError(
-                "This variable should be a string value, check the following variable:",
+                f"The value '{value}' should be a string. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -75,7 +75,7 @@ def validate_uri(
     if not looks_like_uri(value):
         return [
             ValidateModelPropertiesError(
-                "This variable is not a valid uri.",
+                f"The value '{value}' should be a URI. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -94,7 +94,7 @@ def validate_int_type(
     if isinstance(value, bool) or not isinstance(value, int):
         return [
             ValidateModelPropertiesError(
-                "This variable should be a integer value, check the following variable:",
+                f"The value '{value}' should be an integer. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -113,7 +113,7 @@ def boolean(
     if not isinstance(value, bool):
         return [
             ValidateModelPropertiesError(
-                "This variable should be a boolean value, check the following variable:",
+                f"This value '{value}' should be a boolean value. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -151,7 +151,7 @@ def validate_float_type(
     if not isinstance(value, float):
         return [
             ValidateModelPropertiesError(
-                "This variable should be a float value, check the following variable:",
+                f"The value '{value}' should be a float. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -159,7 +159,7 @@ def validate_float_type(
     elif isnan(value):
         return [
             ValidateModelPropertiesError(
-                "This variable should be a float value but is Not a Number (NaN), check the following variable:",
+                f"The value '{value}' should be a float but is Not a Number (NaN). Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -167,7 +167,7 @@ def validate_float_type(
     elif isinf(value):
         return [
             ValidateModelPropertiesError(
-                "This variable should be a float value but is +-infinity, check the following variable:",
+                f"The value '{value}' should be a float but is +-infinity. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -187,7 +187,7 @@ def validate_file(
         if not value.exists():
             return [
                 ValidateModelPropertiesError(
-                    "This file does not exist, check the following variable:",
+                    f"The file '{value}' does not exist. Check the following variable at the property path: '{property_path}'",
                     property_path,
                     value,
                 )
@@ -197,7 +197,7 @@ def validate_file(
     else:
         return [
             ValidateModelPropertiesError(
-                "This is not a valid file path, check the following variable:",
+                f"The file '{value}' is not a valid file path. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 value,
             )
@@ -222,7 +222,7 @@ def any_of(*conditions: ValidationFunction) -> ValidationFunction:
 
         return [
             ValidateModelPropertiesError(
-                "Could not validate any single condition for property with name:",
+                f"The value '{value}' does not satisfy any single condition for variable at the property path: '{property_path}'",
                 property_path,
                 value,
             ),
@@ -247,7 +247,7 @@ def enum(enum_type: Type[Enum]) -> ValidationFunction:
 
         return [
             ValidateModelPropertiesError(
-                f"Could not find matching enum value for '{value}' in {enum_type.__name__} at property:",
+                f"Could not find matching enum value for '{value}' in {enum_type.__name__} at property path: {property_path}",
                 property_path,
                 value,
             )
@@ -266,7 +266,7 @@ def data_type(
     if data_type not in ACCEPTED_DATATYPE_MAPPING.keys():
         return [
             ValidateModelPropertiesError(
-                f"'{data_type}' is not recognised as a valid data type.",
+                f"'{data_type}' is not recognised as a valid data type. Check the following variable at the property path: '{property_path}'",
                 property_path,
                 data_type,
             )
@@ -296,7 +296,7 @@ def validated_model(validated_model_type: Type[ValidatedModel]):
             # This error occurs when runtime validation occurs.
             return [
                 ValidateModelPropertiesError(
-                    f"Value '{value}' was not an instance of the expected type '{validated_model_type.__name__}'.",
+                    f"Value '{value}' was not an instance of the expected type '{validated_model_type.__name__}'. Check the following variable at the property path: '{property_path}'",
                     property_path,
                     value,
                 )
@@ -320,7 +320,7 @@ def is_instance_of(expect_instance_type: Type[object]) -> ValidationFunction:
         if not isinstance(value, expect_instance_type):
             return [
                 ValidateModelPropertiesError(
-                    f"Value '{value}' was not an instance of the expected type '{expect_instance_type.__name__}'.",
+                    f"Value '{value}' was not an instance of the expected type '{expect_instance_type.__name__}'. Check the following variable at the property path: '{property_path}'",
                     property_path,
                     value,
                 ),

--- a/src/csvcubed/utils/validations.py
+++ b/src/csvcubed/utils/validations.py
@@ -42,7 +42,7 @@ def validate_list(
 
 
 def validate_str_type(
-    value: str, property_name: str, property_path: List[str]
+    value: str, property_path: List[str]
 ) -> List[ValidateModelPropertiesError]:
     """
     This function will validate if the argument provided is in fact a string type and,
@@ -52,8 +52,8 @@ def validate_str_type(
         return [
             ValidateModelPropertiesError(
                 "This variable should be a string value, check the following variable:",
-                property_name,
                 property_path,
+                value,
             )
         ]
 
@@ -80,7 +80,7 @@ def validate_uri(value: str, property_name: str) -> List[ValidateModelProperties
 
 
 def validate_int_type(
-    value: int, property_name: str
+    value: int, property_name: str, property_path: List[str]
 ) -> List[ValidateModelPropertiesError]:
     """
     This function will validate if the argument provided is in fact a integer type and,
@@ -91,6 +91,7 @@ def validate_int_type(
             ValidateModelPropertiesError(
                 "This variable should be a integer value, check the following variable:",
                 property_name,
+                property_path,
             )
         ]
 
@@ -122,12 +123,12 @@ def validate_optional(
     """
 
     def _validate(
-        maybe_item: Optional[T], property_name: str, property_path: List[str]
+        maybe_item: Optional[T], property_path: List[str]
     ) -> List[ValidateModelPropertiesError]:
         if maybe_item is None:
             return []
 
-        return validate_item(maybe_item, property_name, property_path)
+        return validate_item(maybe_item, property_path)
 
     return _validate
 
@@ -267,14 +268,15 @@ def validated_model(validated_model_type: Type[ValidatedModel]):
         )
 
     def validate(
-        value: ValidatedModel, property_name: str, property_path: List[str]
+        value: ValidatedModel, property_path: List[str]
     ) -> List[ValidateModelPropertiesError]:
         if not isinstance(value, validated_model_type):
             # This error occurs when runtime validation occurs.
             return [
                 ValidateModelPropertiesError(
                     f"Value '{value}' was not an instance of the expected type '{validated_model_type.__name__}'.",
-                    property_name,
+                    property_path,
+                    value,
                 )
             ]
 

--- a/tests/unit/utils/test_validations.py
+++ b/tests/unit/utils/test_validations.py
@@ -113,7 +113,7 @@ def test_validate_int_type_incorrect():
         result[0].message
         == "This variable should be a integer value, check the following variable:"
     )
-    assert result[0].property_name == "int_test_variable"
+    assert result[0].property_path == ["int_test_variable"]
 
 
 def test_validate_int_type_correct():
@@ -145,7 +145,7 @@ def test_validate_str_type_incorrect():
         result[0].message
         == "This variable should be a string value, check the following variable:"
     )
-    assert result[0].property_name == "str_test_variable"
+    assert result[0].property_path == ["str_test_variable"]
 
 
 def test_validate_str_type_correct():
@@ -180,7 +180,7 @@ def test_validate_list_type_incorrect():
         result[0].message
         == "This variable should be a list, check the following variable:"
     )
-    assert result[0].property_name == "list_test_variable"
+    assert result[0].property_path == ["list_test_variable"]
 
     my_list = ["Something", 8, "Something Else"]
 
@@ -193,7 +193,7 @@ def test_validate_list_type_incorrect():
         result[0].message
         == "This variable should be a string value, check the following variable:"
     )
-    assert result[0].property_name == "list_test_variable"
+    assert result[0].property_path == ["list_test_variable"]
 
 
 def test_validate_list_type_correct():
@@ -278,7 +278,7 @@ def test_validate_float_type_incorrect():
         result[0].message
         == "This variable should be a float value, check the following variable:"
     )
-    assert result[0].property_name == "float_test_variable"
+    assert result[0].property_path == ["float_test_variable"]
 
 
 def test_validate_float_type_nan_incorrect():
@@ -298,7 +298,7 @@ def test_validate_float_type_nan_incorrect():
         result[0].message
         == "This variable should be a float value but is Not a Number (NaN), check the following variable:"
     )
-    assert result[0].property_name == "float_test_variable"
+    assert result[0].property_path == ["float_test_variable"]
 
 
 def test_validate_float_type_infinity_incorrect():
@@ -318,7 +318,7 @@ def test_validate_float_type_infinity_incorrect():
         result[0].message
         == "This variable should be a float value but is +-infinity, check the following variable:"
     )
-    assert result[0].property_name == "float_test_variable"
+    assert result[0].property_path == ["float_test_variable"]
 
 
 def test_validate_float_type_neg_infinity_incorrect():
@@ -338,7 +338,7 @@ def test_validate_float_type_neg_infinity_incorrect():
         result[0].message
         == "This variable should be a float value but is +-infinity, check the following variable:"
     )
-    assert result[0].property_name == "float_test_variable"
+    assert result[0].property_path == ["float_test_variable"]
 
 
 def test_validate_float_type_correct():
@@ -388,7 +388,7 @@ def test_validate_file_not_exists():
     assert (
         result[0].message == "This file does not exist, check the following variable:"
     )
-    assert result[0].property_name == "path_test_variable"
+    assert result[0].property_path == ["path_test_variable"]
 
 
 def test_validate_file_not_a_path():
@@ -407,7 +407,7 @@ def test_validate_file_not_a_path():
         result[0].message
         == "This is not a valid file path, check the following variable:"
     )
-    assert result[0].property_name == "path_test_variable"
+    assert result[0].property_path == ["path_test_variable"]
 
 
 def test_validate_datetime_correct():
@@ -454,7 +454,7 @@ def test_validate_date_incorrect():
         result[0].message
         == "Value 'test' was not an instance of the expected type 'date'."
     )
-    assert result[0].property_name == "date_test_variable"
+    assert result[0].property_path == ["date_test_variable"]
 
 
 def test_validate_enum_correct():
@@ -526,16 +526,16 @@ def test_validated_model_validation_correct():
     assert not any(errors)
 
 
-@dataclass
-class TestingTestClass(ValidatedModel):
-    test_validated_model_class: Optional[OtherTestClass] = None
+# @dataclass
+# class TestingTestClass(ValidatedModel):
+#     test_validated_model_class: Optional[OtherTestClass] = None
 
-    def _get_validations(self) -> Dict[str, ValidationFunction]:
-        return {
-            "test_validated_model_class": validate_optional(
-                v.validated_model(OtherTestClass)
-            ),
-        }
+#     def _get_validations(self) -> Dict[str, ValidationFunction]:
+#         return {
+#             "test_validated_model_class": validate_optional(
+#                 v.validated_model(OtherTestClass)
+#             ),
+#         }
 
 
 def test_validated_model_validation_incorrect_type():
@@ -543,7 +543,7 @@ def test_validated_model_validation_incorrect_type():
     Tests whether a class using validated_model to validate an object of a type which inherits from the
     ValidatedModel class returns errors when given an incorrect object type.
     """
-    test_instance = TestingTestClass(
+    test_instance = TestClass(
         test_validated_model_class=OtherTestClass(str_test_variable_2=3.14)
     )
 
@@ -596,7 +596,9 @@ class WholeObjectValidationsTestClass(ValidatedModel):
             if the_instance.test_validate_int < 0:
                 errors.append(
                     ValidateModelPropertiesError(
-                        "Expected a positive integer", "Whole Object"
+                        "Expected a positive integer",
+                        "Whole Object",
+                        offending_value=the_instance,
                     )
                 )
         else:

--- a/tests/unit/utils/test_validations.py
+++ b/tests/unit/utils/test_validations.py
@@ -19,6 +19,7 @@ from csvcubed.models.validatedmodel import (
 )
 from csvcubed.models.validationerror import ValidateModelPropertiesError
 from csvcubed.utils import validations as v
+from csvcubed.utils.text import truncate
 from tests.unit.test_baseunit import get_test_cases_dir
 
 _test_case_base_dir = get_test_cases_dir() / "cli" / "inspect"
@@ -418,7 +419,7 @@ def test_validate_file_not_exists():
 
     assert len(result) == 1
     assert (
-        "The file '/workspaces/csvcubed/tests/test-cases/cli/inspect/…' does not exist."
+        f"The file '{truncate(str(test_instance.path_test_variable), 50)}' does not exist."
         in result[0].message
     )
     assert result[0].property_path == ["path_test_variable"]

--- a/tests/unit/utils/test_validations.py
+++ b/tests/unit/utils/test_validations.py
@@ -419,7 +419,7 @@ def test_validate_file_not_exists():
     assert len(result) == 1
     assert (
         result[0].message
-        == "The file '/workspaces/csvcubed/tests/test-cases/cli/inspect/not_a_csv_file.csv' does not exist. Check the following variable at the property path: '['path_test_variable']'"
+        == "The file '/workspaces/csvcubed/tests/test-cases/cli/inspect/…' does not exist. Check the following variable at the property path: '['path_test_variable']'"
     )
     assert result[0].property_path == ["path_test_variable"]
     assert result[0].offending_value == _test_case_base_dir / "not_a_csv_file.csv"

--- a/tests/unit/utils/test_validations.py
+++ b/tests/unit/utils/test_validations.py
@@ -345,7 +345,7 @@ def test_validate_float_type_infinity_incorrect():
 
     assert len(result) == 1
     assert (
-        "The value should be a float but is +-infinity. Check the following variable"
+        "The value should be a float but is ±infinity. Check the following variable"
         in result[0].message
     )
     assert result[0].property_path == ["float_test_variable"]
@@ -366,7 +366,7 @@ def test_validate_float_type_neg_infinity_incorrect():
 
     assert len(result) == 1
     assert (
-        "The value should be a float but is +-infinity. Check the following variable"
+        "The value should be a float but is ±infinity. Check the following variable"
         in result[0].message
     )
     assert result[0].property_path == ["float_test_variable"]

--- a/tests/unit/utils/test_validations.py
+++ b/tests/unit/utils/test_validations.py
@@ -113,7 +113,7 @@ def test_validate_int_type_incorrect():
         result[0].message
         == "This variable should be a integer value, check the following variable:"
     )
-    assert result[0].property_path == "int_test_variable"
+    assert result[0].property_name == "int_test_variable"
 
 
 def test_validate_int_type_correct():
@@ -526,18 +526,34 @@ def test_validated_model_validation_correct():
     assert not any(errors)
 
 
+@dataclass
+class TestingTestClass(ValidatedModel):
+    test_validated_model_class: Optional[OtherTestClass] = None
+
+    def _get_validations(self) -> Dict[str, ValidationFunction]:
+        return {
+            "test_validated_model_class": validate_optional(
+                v.validated_model(OtherTestClass)
+            ),
+        }
+
+
 def test_validated_model_validation_incorrect_type():
     """
     Tests whether a class using validated_model to validate an object of a type which inherits from the
     ValidatedModel class returns errors when given an incorrect object type.
     """
-    test_instance = TestClass(
+    test_instance = TestingTestClass(
         test_validated_model_class=OtherTestClass(str_test_variable_2=3.14)
     )
 
     errors = test_instance.validate()
 
     assert any(errors)
+    assert errors[0].property_path == [
+        "test_validated_model_class",
+        "str_test_variable_2",
+    ]
 
 
 def test_validated_model_is_not_inherited():
@@ -767,24 +783,6 @@ def test_boolean_incorrect():
     errors = test_instance.validate()
 
     assert any(errors)
-
-
-@dataclass
-class SanityTestClass(ValidatedModel):
-    test_variable: str = "Hello, World"
-
-    def _get_validations(self) -> Dict[str, ValidationFunction]:
-        return {
-            "str_test_variable": validate_str_type,
-        }
-
-
-def test_new_ticket_understanding():
-    """ """
-    test_instance = SanityTestClass(test_variable=False)
-    errors = test_instance.validate()
-    assert any(errors)
-    assert errors[0].property_path == ["test_variable", "False"]
 
 
 if __name__ == "__main__":

--- a/tests/unit/utils/test_validations.py
+++ b/tests/unit/utils/test_validations.py
@@ -129,7 +129,7 @@ def test_validate_int_type_incorrect():
     assert len(result) == 1
     assert (
         result[0].message
-        == "This variable should be a integer value, check the following variable:"
+        == "The value 'test' should be an integer. Check the following variable at the property path: '['int_test_variable']'"
     )
     assert result[0].property_path == ["int_test_variable"]
     assert result[0].offending_value == "test"
@@ -162,7 +162,7 @@ def test_validate_str_type_incorrect():
     assert len(result) == 1
     assert (
         result[0].message
-        == "This variable should be a string value, check the following variable:"
+        == "The value '5' should be a string. Check the following variable at the property path: '['str_test_variable']'"
     )
     assert result[0].property_path == ["str_test_variable"]
     assert result[0].offending_value == 5
@@ -198,7 +198,7 @@ def test_validate_list_type_incorrect():
     assert len(result) == 1
     assert (
         result[0].message
-        == "This variable should be a list, check the following variable:"
+        == "The value 'nope' should be a list. Check the following variable at the property path: '['list_test_variable']'"
     )
     assert result[0].property_path == ["list_test_variable"]
     assert result[0].offending_value == "nope"
@@ -212,7 +212,7 @@ def test_validate_list_type_incorrect():
     assert len(result) == 1
     assert (
         result[0].message
-        == "This variable should be a string value, check the following variable:"
+        == "The value '8' should be a string. Check the following variable at the property path: '['list_test_variable']'"
     )
     assert result[0].property_path == ["list_test_variable"]
     assert result[0].offending_value == 8
@@ -249,7 +249,10 @@ def test_validate_uri_incorrect():
     result = test_instance.validate()
 
     assert len(result) == 1
-    assert result[0].message == "This variable is not a valid uri."
+    assert (
+        result[0].message
+        == "The value 'whatever' should be a URI. Check the following variable at the property path: '['test_uri']'"
+    )
     assert result[0].property_path == ["test_uri"]
     assert result[0].offending_value == "whatever"
 
@@ -300,7 +303,7 @@ def test_validate_float_type_incorrect():
     assert len(result) == 1
     assert (
         result[0].message
-        == "This variable should be a float value, check the following variable:"
+        == "The value 'test' should be a float. Check the following variable at the property path: '['float_test_variable']'"
     )
     assert result[0].property_path == ["float_test_variable"]
     assert result[0].offending_value == "test"
@@ -321,7 +324,7 @@ def test_validate_float_type_nan_incorrect():
     assert len(result) == 1
     assert (
         result[0].message
-        == "This variable should be a float value but is Not a Number (NaN), check the following variable:"
+        == "The value 'nan' should be a float but is Not a Number (NaN). Check the following variable at the property path: '['float_test_variable']'"
     )
     assert result[0].property_path == ["float_test_variable"]
     # assert result[0].offending_value == float("nan")
@@ -343,7 +346,7 @@ def test_validate_float_type_infinity_incorrect():
     assert len(result) == 1
     assert (
         result[0].message
-        == "This variable should be a float value but is +-infinity, check the following variable:"
+        == "The value 'inf' should be a float but is +-infinity. Check the following variable at the property path: '['float_test_variable']'"
     )
     assert result[0].property_path == ["float_test_variable"]
     assert result[0].offending_value == float("inf")
@@ -364,7 +367,7 @@ def test_validate_float_type_neg_infinity_incorrect():
     assert len(result) == 1
     assert (
         result[0].message
-        == "This variable should be a float value but is +-infinity, check the following variable:"
+        == "The value '-inf' should be a float but is +-infinity. Check the following variable at the property path: '['float_test_variable']'"
     )
     assert result[0].property_path == ["float_test_variable"]
     assert result[0].offending_value == float("-inf")
@@ -415,7 +418,8 @@ def test_validate_file_not_exists():
 
     assert len(result) == 1
     assert (
-        result[0].message == "This file does not exist, check the following variable:"
+        result[0].message
+        == "The file '/workspaces/csvcubed/tests/test-cases/cli/inspect/not_a_csv_file.csv' does not exist. Check the following variable at the property path: '['path_test_variable']'"
     )
     assert result[0].property_path == ["path_test_variable"]
     assert result[0].offending_value == _test_case_base_dir / "not_a_csv_file.csv"
@@ -435,7 +439,7 @@ def test_validate_file_not_a_path():
     assert len(result) == 1
     assert (
         result[0].message
-        == "This is not a valid file path, check the following variable:"
+        == f"The file 'test' is not a valid file path. Check the following variable at the property path: '['path_test_variable']'"
     )
     assert result[0].property_path == ["path_test_variable"]
     assert result[0].offending_value == "test"
@@ -483,7 +487,7 @@ def test_validate_date_incorrect():
     assert len(result) == 1
     assert (
         result[0].message
-        == "Value 'test' was not an instance of the expected type 'date'."
+        == "Value 'test' was not an instance of the expected type 'date'. Check the following variable at the property path: '['date_test_variable']'"
     )
     assert result[0].property_path == ["date_test_variable"]
     assert result[0].offending_value == "test"
@@ -512,6 +516,12 @@ def test_validate_enum_incorrect():
     errors = test_instance.validate()
 
     assert any(errors)
+    assert (
+        errors[0].message
+        == "Could not find matching enum value for 'OtherTestEnum.First_Value' in TestEnum at property path: ['test_enum_value']"
+    )
+    assert errors[0].property_path == ["test_enum_value"]
+    assert errors[0].offending_value == OtherTestEnum.First_Value
 
 
 def test_validate_any_of_correct():
@@ -542,6 +552,12 @@ def test_validate_any_of_incorrect():
     errors = test_instance.validate()
 
     assert any(errors)
+    assert (
+        errors[0].message
+        == "The value '3.65' does not satisfy any single condition for variable at the property path: '['test_any_of_value']'"
+    )
+    assert errors[0].property_path == ["test_any_of_value"]
+    assert errors[0].offending_value == 3.65
 
 
 def test_validated_model_validation_correct():
@@ -570,6 +586,10 @@ def test_validated_model_validation_incorrect_type():
     errors = test_instance.validate()
 
     assert any(errors)
+    assert (
+        errors[0].message
+        == "The value '3.14' should be a string. Check the following variable at the property path: '['test_validated_model_class', 'str_test_variable_2']'"
+    )
     assert errors[0].property_path == [
         "test_validated_model_class",
         "str_test_variable_2",
@@ -589,6 +609,12 @@ def test_validated_model_is_not_inherited():
     errors = test_instance.validate()
 
     assert any(errors)
+    assert (
+        errors[0].message
+        == "Value 'This is not an instance of the right class.' was not an instance of the expected type 'OtherTestClass'. Check the following variable at the property path: '['test_validated_model_class']'"
+    )
+    assert errors[0].property_path == ["test_validated_model_class"]
+    assert errors[0].offending_value == "This is not an instance of the right class."
 
 
 @dataclass
@@ -656,6 +682,7 @@ def test_whole_object_validation_incorrect():
     )
     errors = test_instance.validate()
     assert any(errors)
+    assert errors[0].message == "Expected a positive integer"
     assert errors[0].property_path == ["Whole Object"]
     assert errors[0].offending_value == -2
 
@@ -678,6 +705,10 @@ def test_validate_is_instance_of_incorrect():
     test_instance = TestClass(test_validate_instance_of="Woof")
     errors = test_instance.validate()
     assert any(errors)
+    assert (
+        errors[0].message
+        == "Value 'Woof' was not an instance of the expected type 'Identifier'. Check the following variable at the property path: '['test_validate_instance_of']'"
+    )
     assert errors[0].property_path == ["test_validate_instance_of"]
     assert errors[0].offending_value == "Woof"
 
@@ -718,6 +749,11 @@ def test_validate_data_type_incorrect():
     )
     errors = test_instance.validate()
     assert any(errors)
+    assert (
+        errors[0].message
+        == "'Definitely not a data type or URI' is not recognised as a valid data type. Check the following variable at the property path: '['test_data_type']'"
+    )
+    # TODO: this is wrong because validate_any_of fails first
     assert errors[0].property_path == ["test_data_type"]
     assert errors[0].offending_value == "Definitely not a data type or URI"
 
@@ -730,6 +766,10 @@ def test_validate_int_fails_when_bool():
     test_instance = TestClass(int_test_variable=True)
     errors = test_instance.validate()
     assert any(errors)
+    assert (
+        errors[0].message
+        == "The value 'True' should be an integer. Check the following variable at the property path: '['int_test_variable']'"
+    )
     assert errors[0].property_path == ["int_test_variable"]
     assert errors[0].offending_value == True
 
@@ -780,6 +820,10 @@ def test_validate_base_unit_scaling_factor_dependency_incorrect():
     test_instance = TestUnitClass(base_unit_scaling_factor=1.5)
     errors = test_instance.validate()
     assert any(errors)
+    assert (
+        errors[0].message
+        == "A value for base unit scaling factor has been specified: '1.5' but no value for base unit has been specified and must be provided."
+    )
     assert errors[0].property_path == ["Whole Object"]
     assert errors[0].offending_value == None
 
@@ -793,6 +837,10 @@ def test_validate_base_unit_conversion_multiplier_dependency_incorrect():
     test_instance = TestUnitClass(si_base_unit_conversion_multiplier=2.0)
     errors = test_instance.validate()
     assert any(errors)
+    assert (
+        errors[0].message
+        == "A value for si base unit conversion multiplier has been specified: '2.0' but no value for qudt quantity kind url has been specified and must be provided."
+    )
     assert errors[0].property_path == ["Whole Object"]
     assert errors[0].offending_value == None
 
@@ -820,6 +868,10 @@ def test_boolean_incorrect():
     errors = test_instance.validate()
 
     assert any(errors)
+    assert (
+        errors[0].message
+        == "This value '5' should be a boolean value. Check the following variable at the property path: '['bool_test_variable']'"
+    )
     assert errors[0].property_path == ["bool_test_variable"]
     assert errors[0].offending_value == 5
 
@@ -876,6 +928,10 @@ def test_primative_inside_list_inside_object():
     errors = test_instance.validate()
 
     assert len(errors) == 1
+    assert (
+        errors[0].message
+        == "The value '8' should be a string. Check the following variable at the property path: '['test_something_else', 'list_test_variable_2']'"
+    )
     assert errors[0].property_path == [
         "test_something_else",
         "list_test_variable_2",
@@ -899,6 +955,10 @@ def test_primative_inside_object_inside_list():
     errors = test_instance.validate()
 
     assert len(errors) == 1
+    assert (
+        errors[0].message
+        == "The value '2.72' should be a string. Check the following variable at the property path: '['objects_list_test_variable', 'str_test_variable_2']'"
+    )
     assert errors[0].property_path == [
         "objects_list_test_variable",
         "str_test_variable_2",
@@ -920,11 +980,20 @@ def test_mutiple_incorrect_primatives():
 
     errors = test_instance.validate()
 
-    assert any(errors)
+    assert len(errors) == 2
+    assert (
+        errors[0].message
+        == "The value 'Not an int' should be an integer. Check the following variable at the property path: '['int_test_variable']'"
+    )
     assert errors[0].property_path == [
         "int_test_variable",
     ]
     assert errors[0].offending_value == "Not an int"
+
+    assert (
+        errors[1].message
+        == "The value '3.14' should be a string. Check the following variable at the property path: '['test_validated_model_class', 'str_test_variable_2']'"
+    )
     assert errors[1].property_path == [
         "test_validated_model_class",
         "str_test_variable_2",

--- a/tests/unit/utils/test_validations.py
+++ b/tests/unit/utils/test_validations.py
@@ -421,7 +421,7 @@ def test_validate_file_not_a_path():
     assert len(result) == 1
     assert (
         result[0].message
-        == f"The file 'test' is not a valid file path. Check the following variable at the property path: '['path_test_variable']'"
+        == "The file 'test' is not a valid file path. Check the following variable at the property path: '['path_test_variable']'"
     )
     assert result[0].property_path == ["path_test_variable"]
     assert result[0].offending_value == "test"
@@ -854,43 +854,6 @@ def test_boolean_incorrect():
     )
     assert errors[0].property_path == ["bool_test_variable"]
     assert errors[0].offending_value == 5
-
-
-def test_primative_at_the_top_level():
-    """
-    Test to ensure that when a primative at the top level of a class is incorrect
-    the returned property_path only contains a single element (name of the incorrect
-    property).
-    """
-    test_instance = TestClass(str_test_variable=5.5)
-
-    errors = test_instance.validate()
-
-    assert any(errors)
-    assert errors[0].property_path == ["str_test_variable"]
-    assert errors[0].offending_value == 5.5
-    # TODO: This test is the same as the test str one - probably will delete
-
-
-def test_primative_inside_nested_object():
-    """
-    Test to ensure that when a primative inside a nested object within a class is
-    incorrect the returned property_path contains elements corresponding to the
-    depth property in the nested object.
-    """
-    test_instance = TestClass(
-        test_validated_model_class=OtherTestClass(str_test_variable_2=3.14)
-    )
-
-    errors = test_instance.validate()
-
-    assert any(errors)
-    assert errors[0].property_path == [
-        "test_validated_model_class",
-        "str_test_variable_2",
-    ]
-    assert errors[0].offending_value == 3.14
-    # TODO: This test is the same as the validated model validation - probably will delete
 
 
 def test_primative_inside_list_inside_object():

--- a/tests/unit/utils/test_validations.py
+++ b/tests/unit/utils/test_validations.py
@@ -113,7 +113,7 @@ def test_validate_int_type_incorrect():
         result[0].message
         == "This variable should be a integer value, check the following variable:"
     )
-    assert result[0].property_name == "int_test_variable"
+    assert result[0].property_path == "int_test_variable"
 
 
 def test_validate_int_type_correct():

--- a/tests/unit/utils/test_validations.py
+++ b/tests/unit/utils/test_validations.py
@@ -769,5 +769,23 @@ def test_boolean_incorrect():
     assert any(errors)
 
 
+@dataclass
+class SanityTestClass(ValidatedModel):
+    test_variable: str = "Hello, World"
+
+    def _get_validations(self) -> Dict[str, ValidationFunction]:
+        return {
+            "str_test_variable": validate_str_type,
+        }
+
+
+def test_new_ticket_understanding():
+    """ """
+    test_instance = SanityTestClass(test_variable=False)
+    errors = test_instance.validate()
+    assert any(errors)
+    assert errors[0].property_path == ["test_variable", "False"]
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/unit/utils/test_validations.py
+++ b/tests/unit/utils/test_validations.py
@@ -324,7 +324,7 @@ def test_validate_float_type_nan_incorrect():
 
     assert len(result) == 1
     assert (
-        "The value 'nan' should be a float but is Not a Number (NaN). Check the following variable"
+        "The value should be a float but is Not a Number (NaN). Check the following variable"
         in result[0].message
     )
     assert result[0].property_path == ["float_test_variable"]
@@ -345,7 +345,7 @@ def test_validate_float_type_infinity_incorrect():
 
     assert len(result) == 1
     assert (
-        "The value 'inf' should be a float but is +-infinity. Check the following variable"
+        "The value should be a float but is +-infinity. Check the following variable"
         in result[0].message
     )
     assert result[0].property_path == ["float_test_variable"]
@@ -366,7 +366,7 @@ def test_validate_float_type_neg_infinity_incorrect():
 
     assert len(result) == 1
     assert (
-        "The value '-inf' should be a float but is +-infinity. Check the following variable"
+        "The value should be a float but is +-infinity. Check the following variable"
         in result[0].message
     )
     assert result[0].property_path == ["float_test_variable"]
@@ -554,7 +554,7 @@ def test_validate_any_of_incorrect():
 
     assert any(errors)
     assert (
-        "The value '3.65' does not satisfy any single condition for variable at the property path:"
+        "The value '3.65' does not satisfy any single condition for the variable."
         in errors[0].message
     )
     assert errors[0].property_path == ["test_any_of_value"]
@@ -685,7 +685,7 @@ def test_whole_object_validation_incorrect():
     )
     errors = test_instance.validate()
     assert any(errors)
-    assert errors[0].message == "Expected a positive integer"
+    assert "Expected a positive integer" in errors[0].message
     assert errors[0].property_path == []
     assert errors[0].offending_value == test_instance
 
@@ -837,7 +837,7 @@ def test_primative_inside_list_inside_object():
     """
     Test to ensure that when a primative inside a list within a nested object is
     incorrect the returned property_path contains elements corresponding to the
-    depth property in the nested object.
+    offending property's depth in the nested object.
     """
     test_instance = TestClass(
         test_validated_model_class=OtherTestClass(
@@ -864,7 +864,7 @@ def test_primative_inside_object_inside_list():
     """
     Test to ensure that when a primative inside a nested object stored in a list is
     incorrect the returned property_path contains elements corresponding to the
-    depth property in the nested object.
+    offending property's depth in the nested object.
     """
     test_instance = TestClass(
         objects_list_test_variable=[
@@ -918,7 +918,9 @@ def test_mutiple_incorrect_primatives():
 
 def test_whole_object_in_parent_class():
     """
-    Tests
+    Tests that when whole object validation of an object belonging to a parent class
+    fails, the property path for the offending property is the property name of the
+    whole object.
     """
     test_instance = TestClass(
         test_unit_whole_obj=TestUnitClass(si_base_unit_conversion_multiplier=5.9)

--- a/tests/unit/utils/test_validations.py
+++ b/tests/unit/utils/test_validations.py
@@ -554,6 +554,7 @@ def test_validated_model_validation_incorrect_type():
         "test_validated_model_class",
         "str_test_variable_2",
     ]
+    assert errors[0].offending_value == 3.14
 
 
 def test_validated_model_is_not_inherited():

--- a/tests/unit/utils/test_validations.py
+++ b/tests/unit/utils/test_validations.py
@@ -18,16 +18,6 @@ from csvcubed.models.validatedmodel import (
 )
 from csvcubed.models.validationerror import ValidateModelPropertiesError
 from csvcubed.utils import validations as v
-from csvcubed.utils.validations import (
-    boolean,
-    validate_file,
-    validate_float_type,
-    validate_int_type,
-    validate_list,
-    validate_optional,
-    validate_str_type,
-    validate_uri,
-)
 from tests.unit.test_baseunit import get_test_cases_dir
 
 _test_case_base_dir = get_test_cases_dir() / "cli" / "inspect"
@@ -47,7 +37,7 @@ class OtherTestClass(ValidatedModel):
 
     def _get_validations(self) -> Dict[str, ValidationFunction]:
         return {
-            "str_test_variable_2": validate_str_type,
+            "str_test_variable_2": v.string,
         }
 
 
@@ -56,7 +46,7 @@ class AnotherTestClass(ValidatedModel):
     list_test_variable_2: List[str]
 
     def _get_validations(self) -> Dict[str, ValidationFunction]:
-        return {"list_test_variable_2": validate_list(validate_str_type)}
+        return {"list_test_variable_2": v.list(v.string)}
 
 
 @dataclass
@@ -82,32 +72,24 @@ class TestClass(ValidatedModel):
 
     def _get_validations(self) -> Dict[str, ValidationFunction]:
         return {
-            "str_test_variable": validate_str_type,
-            "int_test_variable": validate_int_type,
-            "bool_test_variable": boolean,
-            "float_test_variable": validate_float_type,
-            "list_test_variable": validate_list(validate_str_type),
-            "objects_list_test_variable": validate_list(
-                validate_optional(v.validated_model(OtherTestClass))
+            "str_test_variable": v.string,
+            "int_test_variable": v.integer,
+            "bool_test_variable": v.boolean,
+            "float_test_variable": v.float,
+            "list_test_variable": v.list(v.string),
+            "objects_list_test_variable": v.list(
+                v.optional(v.validated_model(OtherTestClass))
             ),
-            "path_test_variable": validate_optional(validate_file),
-            "date_test_variable": validate_optional(v.is_instance_of(date)),
-            "date_time_test_variable": validate_optional(v.is_instance_of(datetime)),
-            "test_uri": validate_optional(validate_uri),
-            "test_enum_value": validate_optional(v.enum(TestEnum)),
-            "test_any_of_value": validate_optional(
-                v.any_of(validate_str_type, validate_int_type)
-            ),
-            "test_validated_model_class": validate_optional(
-                v.validated_model(OtherTestClass)
-            ),
-            "test_something_else": validate_optional(
-                v.validated_model(AnotherTestClass)
-            ),
-            "test_data_type": validate_optional(v.any_of(v.data_type, validate_uri)),
-            "test_validate_instance_of": validate_optional(
-                v.is_instance_of(Identifier)
-            ),
+            "path_test_variable": v.optional(v.file),
+            "date_test_variable": v.optional(v.is_instance_of(date)),
+            "date_time_test_variable": v.optional(v.is_instance_of(datetime)),
+            "test_uri": v.optional(v.uri),
+            "test_enum_value": v.optional(v.enum(TestEnum)),
+            "test_any_of_value": v.optional(v.any_of(v.string, v.integer)),
+            "test_validated_model_class": v.optional(v.validated_model(OtherTestClass)),
+            "test_something_else": v.optional(v.validated_model(AnotherTestClass)),
+            "test_data_type": v.optional(v.any_of(v.data_type, v.uri)),
+            "test_validate_instance_of": v.optional(v.is_instance_of(Identifier)),
         }
 
 
@@ -629,8 +611,8 @@ class WholeObjectValidationsTestClass(ValidatedModel):
     def _get_validations(self) -> Union[Validations, Dict[str, ValidationFunction]]:
         return Validations(
             individual_property_validations={
-                "test_validate_str": validate_str_type,
-                "test_validate_int": validate_int_type,
+                "test_validate_str": v.string,
+                "test_validate_int": v.integer,
             },
             whole_object_validations=[self._whole_object_validation],
         )
@@ -753,7 +735,7 @@ def test_validate_data_type_incorrect():
         errors[0].message
         == "'Definitely not a data type or URI' is not recognised as a valid data type. Check the following variable at the property path: '['test_data_type']'"
     )
-    # TODO: this is wrong because validate_any_of fails first
+    # TODO: this (^) is wrong because validate_any_of fails first
     assert errors[0].property_path == ["test_data_type"]
     assert errors[0].offending_value == "Definitely not a data type or URI"
 
@@ -786,12 +768,10 @@ class TestUnitClass(QbUnit):
     def _get_validations(self) -> Union[Validations, Dict[str, ValidationFunction]]:
         return Validations(
             individual_property_validations={
-                "base_unit": validate_optional(v.validated_model(QbUnit)),
-                "base_unit_scaling_factor": validate_optional(validate_float_type),
-                "qudt_quantity_kind_uri": validate_optional(validate_uri),
-                "si_base_unit_conversion_multiplier": validate_optional(
-                    validate_float_type
-                ),
+                "base_unit": v.optional(v.validated_model(QbUnit)),
+                "base_unit_scaling_factor": v.optional(v.float),
+                "qudt_quantity_kind_uri": v.optional(v.uri),
+                "si_base_unit_conversion_multiplier": v.optional(v.float),
             },
             whole_object_validations=[
                 NewQbUnit._validation_base_unit_scaling_factor_dependency


### PR DESCRIPTION
PR to satisfy ticket #676

Changes the information shown to the user in the event of a validation error by adding `property_path` and `offending_value` properties to `ValidateModelPropertiesError`.

`property_path` replaces the existing `property_name` property and takes the form of a list which drills down from the highest validated object to the offending property. 
Combining this with the `offending_value` should make it clear to the user where the error lies and what needs to be changed to satisfy the validation.

All relevant unit tests have been altered to reflect this change and some new ones added to demonstrate scenarios where property paths are constructed as properties belonging to higher level objects or when they are nested in lists.

Other changes:
- Adding truncation (to 50 chars) of offending values in the validation messages
- Updating references to the validation function so they all take the form `v.what_is_being_validated` E.g. `v.string` 