### PR TITLE
New attribute literal `label` set as Optional

### DIFF
--- a/src/csvcubed/readers/cubeconfig/v1/columnschema.py
+++ b/src/csvcubed/readers/cubeconfig/v1/columnschema.py
@@ -278,8 +278,8 @@ class ExistingAttributeResource(SchemaBaseClass):
 
 @dataclass
 class NewAttributeLiteral(SchemaBaseClass):
-    label: str
     data_type: str
+    label: Optional[str] = None
     description: Optional[str] = None
     from_existing: Optional[str] = None
     definition_uri: Optional[str] = None


### PR DESCRIPTION
Bug fix - changed NewAttributeLiteral `label` to Optional[str] - if `label` not provided, it defaults to the column title.