### PR TITLE
747 pandas df function

### DIFF
--- a/src/csvcubed/utils/json.py
+++ b/src/csvcubed/utils/json.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 
 from jsonschema import RefResolver
 
-from csvcubed.utils.uri import get_absolute_file_path, looks_like_uri
+from csvcubed.utils.uri import file_uri_to_path, looks_like_uri
 
 from .cache import session
 
@@ -36,7 +36,7 @@ def load_json_document(file_uri_or_path: Union[str, Path]) -> Dict[str, Any]:
     else:
         url = urlparse(file_uri_or_path)
         if url.scheme == "file":
-            file_path = get_absolute_file_path(file_uri_or_path)
+            file_path = file_uri_to_path(file_uri_or_path)
             return _load_json_from_path(file_path)
         else:
             # Treat it as a URL

--- a/src/csvcubed/utils/json.py
+++ b/src/csvcubed/utils/json.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 
 from jsonschema import RefResolver
 
-from csvcubed.utils.uri import looks_like_uri
+from csvcubed.utils.uri import get_absolute_file_path, looks_like_uri
 
 from .cache import session
 
@@ -36,11 +36,7 @@ def load_json_document(file_uri_or_path: Union[str, Path]) -> Dict[str, Any]:
     else:
         url = urlparse(file_uri_or_path)
         if url.scheme == "file":
-            file_path = Path(
-                os.path.normpath(file_uri_or_path)
-                .removeprefix("file:\\")
-                .removeprefix("file:")
-            )
+            file_path = get_absolute_file_path(file_uri_or_path)
             return _load_json_from_path(file_path)
         else:
             # Treat it as a URL

--- a/src/csvcubed/utils/pandas.py
+++ b/src/csvcubed/utils/pandas.py
@@ -2,7 +2,7 @@
 Pandas Utils
 ------------
 
-This file provides additional utilities for pandas typoe commands
+This file provides additional utilities for pandas type commands
 """
 import logging
 from pathlib import Path

--- a/src/csvcubed/utils/qb/components.py
+++ b/src/csvcubed/utils/qb/components.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 
 from csvcubed.definitions import QB_MEASURE_TYPE_DIMENSION_URI, SDMX_ATTRIBUTE_UNIT_URI
 from csvcubed.models.csvcubedexception import UnsupportedComponentPropertyTypeException
-from csvcubed.utils.uri import get_absolute_file_path
+from csvcubed.utils.uri import file_uri_to_path
 
 
 class ComponentField(Enum):
@@ -138,7 +138,7 @@ def _relative_path(path_uri: str, relative_to: Path) -> str:
 
     if len(url.fragment) > 0:
         fragment_part = "#" + url.fragment
-        file_path = get_absolute_file_path(path_uri.removesuffix(fragment_part))
+        file_path = file_uri_to_path(path_uri.removesuffix(fragment_part))
         relative_file_path: str = os.path.relpath(file_path, relative_to)
         return relative_file_path + fragment_part
 

--- a/src/csvcubed/utils/qb/components.py
+++ b/src/csvcubed/utils/qb/components.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 
 from csvcubed.definitions import QB_MEASURE_TYPE_DIMENSION_URI, SDMX_ATTRIBUTE_UNIT_URI
 from csvcubed.models.csvcubedexception import UnsupportedComponentPropertyTypeException
+from csvcubed.utils.uri import get_absolute_file_path
 
 
 class ComponentField(Enum):
@@ -137,11 +138,7 @@ def _relative_path(path_uri: str, relative_to: Path) -> str:
 
     if len(url.fragment) > 0:
         fragment_part = "#" + url.fragment
-        file_path = Path(
-            os.path.normpath(path_uri.removesuffix(fragment_part))
-            .removeprefix("file:\\")
-            .removeprefix("file:")
-        )
+        file_path = get_absolute_file_path(path_uri.removesuffix(fragment_part))
         relative_file_path: str = os.path.relpath(file_path, relative_to)
         return relative_file_path + fragment_part
 

--- a/src/csvcubed/utils/sparql_handler/code_list_inspector.py
+++ b/src/csvcubed/utils/sparql_handler/code_list_inspector.py
@@ -100,3 +100,12 @@ class CodeListInspector:
             )
 
         return result
+
+    def get_primary_csv_url(self) -> str:
+        """
+        Retrieves the csv_url for the primary CSV defined in the CSV-W.
+        """
+        primary_catalog_metadata = self.csvw_inspector.get_primary_catalog_metadata()
+        return self.get_table_identifiers_for_concept_scheme(
+            primary_catalog_metadata.dataset_uri
+        ).csv_url

--- a/src/csvcubed/utils/sparql_handler/code_list_inspector.py
+++ b/src/csvcubed/utils/sparql_handler/code_list_inspector.py
@@ -104,6 +104,8 @@ class CodeListInspector:
     def get_primary_csv_url(self) -> str:
         """
         Retrieves the csv_url for the primary CSV defined in the CSV-W.
+        This will only work if the primary file loaded into the graph was a
+        code list.
         """
         primary_catalog_metadata = self.csvw_inspector.get_primary_catalog_metadata()
         return self.get_table_identifiers_for_concept_scheme(

--- a/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
+++ b/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
@@ -260,7 +260,7 @@ class DataCubeInspector:
                 .removeprefix("file:")
             )
         )
-        return read_csv(absolute_csv_url, dtype=dict_of_types)
+        return read_csv(Path(absolute_csv_url), dtype=dict_of_types)
 
     @cache
     def get_column_component_info(self, csv_url: str) -> List[ColumnComponentInfo]:

--- a/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
+++ b/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
@@ -35,7 +35,6 @@ from csvcubed.utils.pandas import read_csv
 from csvcubed.utils.qb.components import ComponentPropertyType, EndUserColumnType
 from csvcubed.utils.sparql_handler.column_component_info import ColumnComponentInfo
 from csvcubed.utils.sparql_handler.csvw_inspector import CsvWInspector
-from csvcubed.utils.sparql_handler.sparql import path_to_file_uri_for_rdflib
 from csvcubed.utils.sparql_handler.sparqlquerymanager import (
     select_csvw_dsd_qube_components,
     select_data_set_dsd_and_csv_url,

--- a/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
+++ b/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
@@ -40,7 +40,7 @@ from csvcubed.utils.sparql_handler.sparqlquerymanager import (
     select_is_pivoted_shape_for_measures_in_data_set,
     select_units,
 )
-from csvcubed.utils.uri import get_absolute_file_path
+from csvcubed.utils.uri import file_uri_to_path
 
 _XSD_BASE_URI: str = XSD[""].toPython()
 
@@ -224,7 +224,7 @@ class DataCubeInspector:
         """
         cols = self.get_column_component_info(csv_url)
         dict_of_types = _get_data_types_of_all_cols(cols)
-        absolute_csv_url = get_absolute_file_path(
+        absolute_csv_url = file_uri_to_path(
             urljoin(self.csvw_inspector.csvw_json_path.as_uri(), csv_url)
         )
         return read_csv(absolute_csv_url, dtype=dict_of_types)

--- a/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
+++ b/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
@@ -233,9 +233,14 @@ class DataCubeInspector:
                 col.column_type == EndUserColumnType.Observations
                 or is_attribute_literal
             ):
-                col_data_type = col.column_definition.data_type.removeprefix(
-                    _XSD_BASE_URI
-                )
+                if col.column_definition.data_type is not None:
+                    col_data_type = col.column_definition.data_type.removeprefix(
+                        _XSD_BASE_URI
+                    )
+                else:
+                    raise ValueError(
+                        "Expected a defined datatype but got 'None' instead."
+                    )
                 if col_data_type in ACCEPTED_DATATYPE_MAPPING.keys():
                     dict_of_types[
                         col.column_definition.title

--- a/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
+++ b/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
@@ -7,8 +7,10 @@ one of more data cubes.
 """
 
 from dataclasses import dataclass
-from functools import cached_property, cache
-from typing import Dict, List, Optional, Tuple, Set
+from functools import cache, cached_property
+from typing import Dict, List, Optional, Set, Tuple
+
+import pandas as pd
 
 from csvcubed.definitions import QB_MEASURE_TYPE_DIMENSION_URI, SDMX_ATTRIBUTE_UNIT_URI
 from csvcubed.models.csvcubedexception import UnsupportedComponentPropertyTypeException
@@ -24,6 +26,7 @@ from csvcubed.models.sparqlresults import (
 )
 from csvcubed.utils.dict import get_from_dict_ensure_exists
 from csvcubed.utils.iterables import first, group_by
+from csvcubed.utils.pandas import read_csv
 from csvcubed.utils.qb.components import ComponentPropertyType, EndUserColumnType
 from csvcubed.utils.sparql_handler.column_component_info import ColumnComponentInfo
 from csvcubed.utils.sparql_handler.csvw_inspector import CsvWInspector
@@ -147,6 +150,21 @@ class DataCubeInspector:
             self.csvw_inspector.csvw_json_path,
         )
 
+    @cached_property
+    def _load_dataframe(self) -> pd.DataFrame:
+        """
+        TODO: This
+        TODO: Do we even want this as a cached property?
+        """
+        # df = read_csv(self.csvw_inspector.get_primary_catalog_metadata().dataset_uri)
+        # df = read_csv(
+        #     self.get_cube_identifiers_for_csv(
+        #         self.csvw_inspector.get_primary_catalog_metadata().dataset_uri
+        #     ).csv_url
+        # )
+        # csv_url = csv_url
+        # return read_csv(csv_url)
+
     """
     Public getters for the cached properties.
     """
@@ -206,6 +224,18 @@ class DataCubeInspector:
         """
 
         return self._codelists_and_cols.get(csv_url, CodelistsResult([], 0))
+
+    def get_dataframe(self, csv_url: str) -> pd.DataFrame:
+        """
+        TODO: This and maybe change API function name.
+        """
+        # return self._load_dataframe(csv_url)
+        df: pd.DataFrame = read_csv(csv_url)
+
+        #
+
+        # df.astype({}).dtypes
+        return df
 
     @cache
     def get_column_component_info(self, csv_url: str) -> List[ColumnComponentInfo]:

--- a/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
+++ b/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
@@ -18,6 +18,7 @@ from csvcubedmodels.rdf.namespaces import XSD
 from csvcubed.definitions import QB_MEASURE_TYPE_DIMENSION_URI, SDMX_ATTRIBUTE_UNIT_URI
 from csvcubed.models.csvcubedexception import UnsupportedComponentPropertyTypeException
 from csvcubed.models.cube.cube_shape import CubeShape
+from csvcubed.models.cube.qb.components.constants import ACCEPTED_DATATYPE_MAPPING
 from csvcubed.models.sparqlresults import (
     CodelistsResult,
     ColumnDefinition,
@@ -220,18 +221,11 @@ class DataCubeInspector:
         """
         TODO: This and maybe change API function name.
         """
-        from csvcubed.models.cube.qb.components.constants import (
-            ACCEPTED_DATATYPE_MAPPING,
-        )
-
         cols = self.get_column_component_info(csv_url)
         dict_of_types = {}
         for col in cols:
             is_attribute_literal = (
                 col.column_type == EndUserColumnType.Attribute
-                # Attribute Resources need to have the value_url set to point
-                # at the resource.
-                # http://example.com/my-attribute-values/{+column_name}
                 and col.column_definition.value_url is None
             )
 

--- a/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
+++ b/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
@@ -5,7 +5,7 @@ Data Cube Inspector
 Provides access to inspect the contents of an rdflib graph containing
 one of more data cubes.
 """
-
+import os
 from dataclasses import dataclass
 from functools import cache, cached_property
 from pathlib import Path
@@ -253,12 +253,12 @@ class DataCubeInspector:
             else:
                 dict_of_types[col.column_definition.title] = "string"
 
-        absolute_csv_url = path_to_file_uri_for_rdflib(
-            Path(
+        absolute_csv_url = Path(
+            os.path.normpath(
                 urljoin(self.csvw_inspector.csvw_json_path.as_uri(), csv_url)
-                .removeprefix("file:\\")
-                .removeprefix("file:")
             )
+            .removeprefix("file:\\")
+            .removeprefix("file:")
         )
         return read_csv(Path(absolute_csv_url), dtype=dict_of_types)
 

--- a/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
+++ b/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
@@ -219,7 +219,7 @@ class DataCubeInspector:
 
     def get_dataframe(self, csv_url: str) -> Tuple[pd.DataFrame, List[ValidationError]]:
         """
-        TODO: This and maybe change API function name.
+        Get the pandas dataframe for the csv url of the cube wishing to be loaded.
         """
         cols = self.get_column_component_info(csv_url)
         dict_of_types = {}

--- a/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
+++ b/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
@@ -35,6 +35,7 @@ from csvcubed.utils.pandas import read_csv
 from csvcubed.utils.qb.components import ComponentPropertyType, EndUserColumnType
 from csvcubed.utils.sparql_handler.column_component_info import ColumnComponentInfo
 from csvcubed.utils.sparql_handler.csvw_inspector import CsvWInspector
+from csvcubed.utils.sparql_handler.sparql import path_to_file_uri_for_rdflib
 from csvcubed.utils.sparql_handler.sparqlquerymanager import (
     select_csvw_dsd_qube_components,
     select_data_set_dsd_and_csv_url,
@@ -252,10 +253,12 @@ class DataCubeInspector:
             else:
                 dict_of_types[col.column_definition.title] = "string"
 
-        absolute_csv_url = Path(
-            urljoin(self.csvw_inspector.csvw_json_path.as_uri(), csv_url)
-            .removeprefix("file:\\")
-            .removeprefix("file:")
+        absolute_csv_url = path_to_file_uri_for_rdflib(
+            Path(
+                urljoin(self.csvw_inspector.csvw_json_path.as_uri(), csv_url)
+                .removeprefix("file:\\")
+                .removeprefix("file:")
+            )
         )
         return read_csv(absolute_csv_url, dtype=dict_of_types)
 

--- a/src/csvcubed/utils/uri.py
+++ b/src/csvcubed/utils/uri.py
@@ -5,8 +5,10 @@ URI
 Functions to help when working with URIs.
 """
 import logging
+import os
 import re
-from urllib.parse import urlparse
+from pathlib import Path
+from urllib.parse import urljoin, urlparse
 
 import rdflib
 from unidecode import unidecode
@@ -112,3 +114,13 @@ def ensure_values_in_lists_looks_like_uris(values: list[str]) -> None:
             raise ValueError(f"'{value}' does not look like a URI.")
 
     _logger.debug("Values %s all look like URIs.", values)
+
+
+def get_absolute_file_path(file_uri: str) -> Path:
+    """
+    Returns a normalised file path from a URI. Will work on both Windows and
+    Linux/Unix.
+    """
+    return Path(
+        os.path.normpath(file_uri).removeprefix("file:\\").removeprefix("file:")
+    )

--- a/src/csvcubed/utils/uri.py
+++ b/src/csvcubed/utils/uri.py
@@ -116,7 +116,7 @@ def ensure_values_in_lists_looks_like_uris(values: list[str]) -> None:
     _logger.debug("Values %s all look like URIs.", values)
 
 
-def get_absolute_file_path(file_uri: str) -> Path:
+def file_uri_to_path(file_uri: str) -> Path:
     """
     Returns a normalised file path from a URI. Will work on both Windows and
     Linux/Unix.

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim1.csv
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim1.csv
@@ -1,0 +1,2 @@
+Uri Identifier,Label,Notation,Parent Uri Identifier,Sort Priority,Description
+value1,Value1,value1,,0,

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim1.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim1.csv-metadata.json
@@ -1,0 +1,64 @@
+{
+    "@context": "http://www.w3.org/ns/csvw",
+    "@id": "dim1.csv#code-list",
+    "url": "dim1.csv",
+    "tableSchema": "dim1.table.json",
+    "rdfs:seeAlso": [
+        {
+            "@id": "dim1.csv#code-list",
+            "@type": [
+                "http://www.w3.org/ns/prov#Entity",
+                "http://www.w3.org/2004/02/skos/core#ConceptScheme",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/dcat#Dataset",
+                "http://www.w3.org/ns/dcat#Resource"
+            ],
+            "http://purl.org/dc/terms/identifier": [
+                {
+                    "@value": "Dim1"
+                }
+            ],
+            "http://purl.org/dc/terms/issued": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:01:10.582061"
+                }
+            ],
+            "http://purl.org/dc/terms/modified": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:01:10.582061"
+                }
+            ],
+            "http://purl.org/dc/terms/title": [
+                {
+                    "@language": "en",
+                    "@value": "Dim1"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Dim1"
+                }
+            ],
+            "http://www.w3.org/ns/prov#wasGeneratedBy": [
+                {
+                    "@id": "dim1.csv#csvcubed-build-activity"
+                }
+            ]
+        },
+        {
+            "@id": "dim1.csv#csvcubed-build-activity",
+            "@type": [
+                "http://www.w3.org/ns/prov#Activity",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ],
+            "http://www.w3.org/ns/prov#used": [
+                {
+                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim1.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim1.csv-metadata.json
@@ -7,11 +7,11 @@
         {
             "@id": "dim1.csv#code-list",
             "@type": [
-                "http://www.w3.org/ns/prov#Entity",
-                "http://www.w3.org/2004/02/skos/core#ConceptScheme",
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/dcat#Resource",
                 "http://www.w3.org/ns/dcat#Dataset",
-                "http://www.w3.org/ns/dcat#Resource"
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/prov#Entity",
+                "http://www.w3.org/2004/02/skos/core#ConceptScheme"
             ],
             "http://purl.org/dc/terms/identifier": [
                 {
@@ -21,13 +21,13 @@
             "http://purl.org/dc/terms/issued": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:01:10.582061"
+                    "@value": "2023-03-31T17:33:01.548352"
                 }
             ],
             "http://purl.org/dc/terms/modified": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:01:10.582061"
+                    "@value": "2023-03-31T17:33:01.548352"
                 }
             ],
             "http://purl.org/dc/terms/title": [
@@ -51,8 +51,8 @@
         {
             "@id": "dim1.csv#csvcubed-build-activity",
             "@type": [
-                "http://www.w3.org/ns/prov#Activity",
-                "http://www.w3.org/2000/01/rdf-schema#Resource"
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/prov#Activity"
             ],
             "http://www.w3.org/ns/prov#used": [
                 {

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim1.table.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim1.table.json
@@ -1,0 +1,58 @@
+{
+    "columns": [
+        {
+            "titles": "Uri Identifier",
+            "name": "uri_identifier",
+            "required": true,
+            "suppressOutput": true
+        },
+        {
+            "titles": "Label",
+            "name": "label",
+            "required": true,
+            "propertyUrl": "rdfs:label"
+        },
+        {
+            "titles": "Notation",
+            "name": "notation",
+            "required": true,
+            "propertyUrl": "skos:notation"
+        },
+        {
+            "titles": "Parent Uri Identifier",
+            "name": "parent_uri_identifier",
+            "required": false,
+            "propertyUrl": "skos:broader",
+            "valueUrl": "dim1.csv#{+parent_uri_identifier}"
+        },
+        {
+            "titles": "Sort Priority",
+            "name": "sort_priority",
+            "required": false,
+            "datatype": "integer",
+            "propertyUrl": "http://www.w3.org/ns/ui#sortPriority"
+        },
+        {
+            "titles": "Description",
+            "name": "description",
+            "required": false,
+            "propertyUrl": "rdfs:comment"
+        },
+        {
+            "virtual": true,
+            "name": "virt_inScheme",
+            "required": true,
+            "propertyUrl": "skos:inScheme",
+            "valueUrl": "dim1.csv#code-list"
+        },
+        {
+            "virtual": true,
+            "name": "virt_type",
+            "required": true,
+            "propertyUrl": "rdf:type",
+            "valueUrl": "skos:Concept"
+        }
+    ],
+    "aboutUrl": "dim1.csv#{+uri_identifier}",
+    "primaryKey": "uri_identifier"
+}

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim2.csv
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim2.csv
@@ -1,0 +1,2 @@
+Uri Identifier,Label,Notation,Parent Uri Identifier,Sort Priority,Description
+value2,value2,value2,,0,

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim2.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim2.csv-metadata.json
@@ -1,0 +1,64 @@
+{
+    "@context": "http://www.w3.org/ns/csvw",
+    "@id": "dim2.csv#code-list",
+    "url": "dim2.csv",
+    "tableSchema": "dim2.table.json",
+    "rdfs:seeAlso": [
+        {
+            "@id": "dim2.csv#csvcubed-build-activity",
+            "@type": [
+                "http://www.w3.org/ns/prov#Activity",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ],
+            "http://www.w3.org/ns/prov#used": [
+                {
+                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0"
+                }
+            ]
+        },
+        {
+            "@id": "dim2.csv#code-list",
+            "@type": [
+                "http://www.w3.org/ns/prov#Entity",
+                "http://www.w3.org/2004/02/skos/core#ConceptScheme",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/dcat#Dataset",
+                "http://www.w3.org/ns/dcat#Resource"
+            ],
+            "http://purl.org/dc/terms/identifier": [
+                {
+                    "@value": "Dim2"
+                }
+            ],
+            "http://purl.org/dc/terms/issued": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:01:10.609559"
+                }
+            ],
+            "http://purl.org/dc/terms/modified": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:01:10.609559"
+                }
+            ],
+            "http://purl.org/dc/terms/title": [
+                {
+                    "@language": "en",
+                    "@value": "Dim2"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Dim2"
+                }
+            ],
+            "http://www.w3.org/ns/prov#wasGeneratedBy": [
+                {
+                    "@id": "dim2.csv#csvcubed-build-activity"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim2.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim2.csv-metadata.json
@@ -7,8 +7,8 @@
         {
             "@id": "dim2.csv#csvcubed-build-activity",
             "@type": [
-                "http://www.w3.org/ns/prov#Activity",
-                "http://www.w3.org/2000/01/rdf-schema#Resource"
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/prov#Activity"
             ],
             "http://www.w3.org/ns/prov#used": [
                 {
@@ -19,11 +19,11 @@
         {
             "@id": "dim2.csv#code-list",
             "@type": [
-                "http://www.w3.org/ns/prov#Entity",
-                "http://www.w3.org/2004/02/skos/core#ConceptScheme",
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/dcat#Resource",
                 "http://www.w3.org/ns/dcat#Dataset",
-                "http://www.w3.org/ns/dcat#Resource"
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/prov#Entity",
+                "http://www.w3.org/2004/02/skos/core#ConceptScheme"
             ],
             "http://purl.org/dc/terms/identifier": [
                 {
@@ -33,13 +33,13 @@
             "http://purl.org/dc/terms/issued": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:01:10.609559"
+                    "@value": "2023-03-31T17:33:01.574522"
                 }
             ],
             "http://purl.org/dc/terms/modified": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:01:10.609559"
+                    "@value": "2023-03-31T17:33:01.574522"
                 }
             ],
             "http://purl.org/dc/terms/title": [

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim2.table.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/dim2.table.json
@@ -1,0 +1,58 @@
+{
+    "columns": [
+        {
+            "titles": "Uri Identifier",
+            "name": "uri_identifier",
+            "required": true,
+            "suppressOutput": true
+        },
+        {
+            "titles": "Label",
+            "name": "label",
+            "required": true,
+            "propertyUrl": "rdfs:label"
+        },
+        {
+            "titles": "Notation",
+            "name": "notation",
+            "required": true,
+            "propertyUrl": "skos:notation"
+        },
+        {
+            "titles": "Parent Uri Identifier",
+            "name": "parent_uri_identifier",
+            "required": false,
+            "propertyUrl": "skos:broader",
+            "valueUrl": "dim2.csv#{+parent_uri_identifier}"
+        },
+        {
+            "titles": "Sort Priority",
+            "name": "sort_priority",
+            "required": false,
+            "datatype": "integer",
+            "propertyUrl": "http://www.w3.org/ns/ui#sortPriority"
+        },
+        {
+            "titles": "Description",
+            "name": "description",
+            "required": false,
+            "propertyUrl": "rdfs:comment"
+        },
+        {
+            "virtual": true,
+            "name": "virt_inScheme",
+            "required": true,
+            "propertyUrl": "skos:inScheme",
+            "valueUrl": "dim2.csv#code-list"
+        },
+        {
+            "virtual": true,
+            "name": "virt_type",
+            "required": true,
+            "propertyUrl": "rdf:type",
+            "valueUrl": "skos:Concept"
+        }
+    ],
+    "aboutUrl": "dim2.csv#{+uri_identifier}",
+    "primaryKey": "uri_identifier"
+}

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/pivoted-shape.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/pivoted-shape.csv-metadata.json
@@ -1,0 +1,628 @@
+{
+    "@context": "http://www.w3.org/ns/csvw",
+    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dataset",
+    "tables": [
+        {
+            "url": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv",
+            "tableSchema": {
+                "columns": [
+                    {
+                        "titles": "Dim1",
+                        "name": "dim1",
+                        "propertyUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1",
+                        "valueUrl": "dim1.csv#{+dim1}",
+                        "required": true
+                    },
+                    {
+                        "titles": "Obs1",
+                        "name": "obs1",
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@some-measure",
+                        "propertyUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure",
+                        "datatype": "time",
+                        "required": true
+                    },
+                    {
+                        "titles": "Dim2",
+                        "name": "dim2",
+                        "propertyUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2",
+                        "valueUrl": "dim2.csv#{+dim2}",
+                        "required": true
+                    },
+                    {
+                        "titles": "Obs2",
+                        "name": "obs2",
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@another-measure",
+                        "propertyUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure",
+                        "datatype": "boolean",
+                        "required": true
+                    },
+                    {
+                        "name": "virt_slice",
+                        "virtual": true,
+                        "propertyUrl": "rdf:type",
+                        "valueUrl": "qb:Slice"
+                    },
+                    {
+                        "name": "virt_slice_structure",
+                        "virtual": true,
+                        "propertyUrl": "qb:sliceStructure",
+                        "valueUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#slice/cross-measures"
+                    },
+                    {
+                        "name": "virt_obs_obs1",
+                        "virtual": true,
+                        "propertyUrl": "qb:observation",
+                        "valueUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@some-measure"
+                    },
+                    {
+                        "name": "virt_obs_obs1_meas",
+                        "virtual": true,
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@some-measure",
+                        "propertyUrl": "qb:measureType",
+                        "valueUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                    },
+                    {
+                        "name": "virt_obs_obs1_unit",
+                        "virtual": true,
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@some-measure",
+                        "propertyUrl": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure",
+                        "valueUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#unit/some-unit"
+                    },
+                    {
+                        "name": "virt_dim_obs1_dim1",
+                        "virtual": true,
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@some-measure",
+                        "propertyUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1",
+                        "valueUrl": "dim1.csv#{+dim1}"
+                    },
+                    {
+                        "name": "virt_dim_obs1_dim2",
+                        "virtual": true,
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@some-measure",
+                        "propertyUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2",
+                        "valueUrl": "dim2.csv#{+dim2}"
+                    },
+                    {
+                        "name": "virt_obs_obs1_type",
+                        "virtual": true,
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@some-measure",
+                        "propertyUrl": "rdf:type",
+                        "valueUrl": "qb:Observation"
+                    },
+                    {
+                        "name": "virt_dataSet_obs1",
+                        "virtual": true,
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@some-measure",
+                        "propertyUrl": "qb:dataSet",
+                        "valueUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dataset"
+                    },
+                    {
+                        "name": "virt_obs_obs2",
+                        "virtual": true,
+                        "propertyUrl": "qb:observation",
+                        "valueUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@another-measure"
+                    },
+                    {
+                        "name": "virt_obs_obs2_meas",
+                        "virtual": true,
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@another-measure",
+                        "propertyUrl": "qb:measureType",
+                        "valueUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure"
+                    },
+                    {
+                        "name": "virt_obs_obs2_unit",
+                        "virtual": true,
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@another-measure",
+                        "propertyUrl": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure",
+                        "valueUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#unit/some-other-unit"
+                    },
+                    {
+                        "name": "virt_dim_obs2_dim1",
+                        "virtual": true,
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@another-measure",
+                        "propertyUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1",
+                        "valueUrl": "dim1.csv#{+dim1}"
+                    },
+                    {
+                        "name": "virt_dim_obs2_dim2",
+                        "virtual": true,
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@another-measure",
+                        "propertyUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2",
+                        "valueUrl": "dim2.csv#{+dim2}"
+                    },
+                    {
+                        "name": "virt_obs_obs2_type",
+                        "virtual": true,
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@another-measure",
+                        "propertyUrl": "rdf:type",
+                        "valueUrl": "qb:Observation"
+                    },
+                    {
+                        "name": "virt_dataSet_obs2",
+                        "virtual": true,
+                        "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2}@another-measure",
+                        "propertyUrl": "qb:dataSet",
+                        "valueUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dataset"
+                    }
+                ],
+                "foreignKeys": [
+                    {
+                        "columnReference": "dim1",
+                        "reference": {
+                            "resource": "dim1.csv",
+                            "columnReference": "uri_identifier"
+                        }
+                    },
+                    {
+                        "columnReference": "dim2",
+                        "reference": {
+                            "resource": "dim2.csv",
+                            "columnReference": "uri_identifier"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "dim1",
+                    "dim2"
+                ],
+                "aboutUrl": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#slice/{dim1},{dim2}"
+            }
+        },
+        {
+            "url": "dim1.csv",
+            "tableSchema": "dim1.table.json",
+            "suppressOutput": true
+        },
+        {
+            "url": "dim2.csv",
+            "tableSchema": "dim2.table.json",
+            "suppressOutput": true
+        }
+    ],
+    "rdfs:seeAlso": [
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/another-measure",
+            "@type": [
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#measure": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 7
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/dim1",
+            "@type": [
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 1
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentProperty",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#MeasureProperty"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Another Measure"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "http://www.w3.org/2001/XMLSchema#time"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentProperty",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#MeasureProperty"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Some Measure"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "http://www.w3.org/2001/XMLSchema#time"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#class/dim2",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Class",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2",
+            "@type": [
+                "http://purl.org/linked-data/cube#CodedProperty",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#DimensionProperty",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#ComponentProperty"
+            ],
+            "http://purl.org/linked-data/cube#codeList": [
+                {
+                    "@id": "dim2.csv#code-list"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Dim2"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#class/dim2"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1",
+            "@type": [
+                "http://purl.org/linked-data/cube#CodedProperty",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#DimensionProperty",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#ComponentProperty"
+            ],
+            "http://purl.org/linked-data/cube#codeList": [
+                {
+                    "@id": "dim1.csv#code-list"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Dim1"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#class/dim1"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/unit",
+            "@type": [
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#attribute": [
+                {
+                    "@id": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentRequired": [
+                {
+                    "@value": true
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 3
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/some-measure",
+            "@type": [
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#measure": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 4
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/measure-type",
+            "@type": [
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 6
+                },
+                {
+                    "@value": 2
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#csvcubed-build-activity",
+            "@type": [
+                "http://www.w3.org/ns/prov#Activity",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ],
+            "http://www.w3.org/ns/prov#used": [
+                {
+                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/dim2",
+            "@type": [
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 5
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#structure",
+            "@type": [
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#DataStructureDefinition"
+            ],
+            "http://purl.org/linked-data/cube#component": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/unit"
+                },
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/another-measure"
+                },
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/some-measure"
+                },
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/dim1"
+                },
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/dim2"
+                },
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/measure-type"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure"
+                },
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                },
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                },
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                },
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1"
+                },
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#sliceKey": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#slice/cross-measures"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dataset",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#DataSet",
+                "http://www.w3.org/ns/dcat#Dataset",
+                "http://www.w3.org/ns/dcat#Resource",
+                "http://purl.org/linked-data/cube#Attachable"
+            ],
+            "http://purl.org/dc/terms/identifier": [
+                {
+                    "@value": "Testing converting a pivoted CSVW to pandas dataframe"
+                }
+            ],
+            "http://purl.org/dc/terms/issued": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:01:10.633164"
+                }
+            ],
+            "http://purl.org/dc/terms/modified": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:01:10.633164"
+                }
+            ],
+            "http://purl.org/dc/terms/title": [
+                {
+                    "@language": "en",
+                    "@value": "Testing converting a pivoted CSVW to pandas dataframe"
+                }
+            ],
+            "http://purl.org/linked-data/cube#structure": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#structure"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Testing converting a pivoted CSVW to pandas dataframe"
+                }
+            ],
+            "http://www.w3.org/ns/prov#wasGeneratedBy": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#csvcubed-build-activity"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#class/dim1",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Class",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#slice/cross-measures",
+            "@type": [
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#SliceKey"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1"
+                },
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dependency/dim1",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://rdfs.org/ns/void#Dataset"
+            ],
+            "http://rdfs.org/ns/void#dataDump": [
+                {
+                    "@id": "./dim1.csv-metadata.json"
+                }
+            ],
+            "http://rdfs.org/ns/void#uriSpace": [
+                {
+                    "@value": "dim1.csv#"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dependency/dim2",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://rdfs.org/ns/void#Dataset"
+            ],
+            "http://rdfs.org/ns/void#dataDump": [
+                {
+                    "@id": "./dim2.csv-metadata.json"
+                }
+            ],
+            "http://rdfs.org/ns/void#uriSpace": [
+                {
+                    "@value": "dim2.csv#"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#unit/some-unit",
+            "@type": [
+                "http://www.ontology-of-units-of-measure.org/resource/om-2/Unit",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://qudt.org/schema/qudt/Unit"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Some Unit"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#unit/some-other-unit",
+            "@type": [
+                "http://www.ontology-of-units-of-measure.org/resource/om-2/Unit",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://qudt.org/schema/qudt/Unit"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Some Other Unit"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv
@@ -1,0 +1,2 @@
+Dim1,Obs1,Dim2,Obs2
+value1,01:02:03,value2,true

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv-metadata.json
@@ -181,155 +181,10 @@
     ],
     "rdfs:seeAlso": [
         {
-            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/another-measure",
-            "@type": [
-                "http://purl.org/linked-data/cube#ComponentSet",
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentSpecification"
-            ],
-            "http://purl.org/linked-data/cube#componentProperty": [
-                {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure"
-                }
-            ],
-            "http://purl.org/linked-data/cube#measure": [
-                {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure"
-                }
-            ],
-            "http://purl.org/linked-data/cube#order": [
-                {
-                    "@value": 7
-                }
-            ]
-        },
-        {
-            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/dim1",
-            "@type": [
-                "http://purl.org/linked-data/cube#ComponentSet",
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentSpecification"
-            ],
-            "http://purl.org/linked-data/cube#componentProperty": [
-                {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1"
-                }
-            ],
-            "http://purl.org/linked-data/cube#dimension": [
-                {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1"
-                }
-            ],
-            "http://purl.org/linked-data/cube#order": [
-                {
-                    "@value": 1
-                }
-            ]
-        },
-        {
-            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure",
-            "@type": [
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentProperty",
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
-                "http://purl.org/linked-data/cube#MeasureProperty"
-            ],
-            "http://www.w3.org/2000/01/rdf-schema#label": [
-                {
-                    "@language": "en",
-                    "@value": "Another Measure"
-                }
-            ],
-            "http://www.w3.org/2000/01/rdf-schema#range": [
-                {
-                    "@id": "http://www.w3.org/2001/XMLSchema#time"
-                }
-            ]
-        },
-        {
-            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure",
-            "@type": [
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentProperty",
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
-                "http://purl.org/linked-data/cube#MeasureProperty"
-            ],
-            "http://www.w3.org/2000/01/rdf-schema#label": [
-                {
-                    "@language": "en",
-                    "@value": "Some Measure"
-                }
-            ],
-            "http://www.w3.org/2000/01/rdf-schema#range": [
-                {
-                    "@id": "http://www.w3.org/2001/XMLSchema#time"
-                }
-            ]
-        },
-        {
-            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#class/dim2",
-            "@type": [
-                "http://www.w3.org/2000/01/rdf-schema#Class",
-                "http://www.w3.org/2000/01/rdf-schema#Resource"
-            ]
-        },
-        {
-            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2",
-            "@type": [
-                "http://purl.org/linked-data/cube#CodedProperty",
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#DimensionProperty",
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
-                "http://purl.org/linked-data/cube#ComponentProperty"
-            ],
-            "http://purl.org/linked-data/cube#codeList": [
-                {
-                    "@id": "dim2.csv#code-list"
-                }
-            ],
-            "http://www.w3.org/2000/01/rdf-schema#label": [
-                {
-                    "@language": "en",
-                    "@value": "Dim2"
-                }
-            ],
-            "http://www.w3.org/2000/01/rdf-schema#range": [
-                {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#class/dim2"
-                }
-            ]
-        },
-        {
-            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1",
-            "@type": [
-                "http://purl.org/linked-data/cube#CodedProperty",
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#DimensionProperty",
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
-                "http://purl.org/linked-data/cube#ComponentProperty"
-            ],
-            "http://purl.org/linked-data/cube#codeList": [
-                {
-                    "@id": "dim1.csv#code-list"
-                }
-            ],
-            "http://www.w3.org/2000/01/rdf-schema#label": [
-                {
-                    "@language": "en",
-                    "@value": "Dim1"
-                }
-            ],
-            "http://www.w3.org/2000/01/rdf-schema#range": [
-                {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#class/dim1"
-                }
-            ]
-        },
-        {
             "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/unit",
             "@type": [
-                "http://purl.org/linked-data/cube#ComponentSet",
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
                 "http://purl.org/linked-data/cube#ComponentSpecification"
             ],
             "http://purl.org/linked-data/cube#attribute": [
@@ -354,114 +209,82 @@
             ]
         },
         {
-            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/some-measure",
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1",
             "@type": [
-                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#CodedProperty",
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentSpecification"
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#DimensionProperty",
+                "http://purl.org/linked-data/cube#ComponentProperty"
             ],
-            "http://purl.org/linked-data/cube#componentProperty": [
+            "http://purl.org/linked-data/cube#codeList": [
                 {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                    "@id": "dim1.csv#code-list"
                 }
             ],
-            "http://purl.org/linked-data/cube#measure": [
+            "http://www.w3.org/2000/01/rdf-schema#label": [
                 {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                    "@language": "en",
+                    "@value": "Dim1"
                 }
             ],
-            "http://purl.org/linked-data/cube#order": [
+            "http://www.w3.org/2000/01/rdf-schema#range": [
                 {
-                    "@value": 4
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#class/dim1"
                 }
             ]
         },
         {
-            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/measure-type",
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2",
             "@type": [
-                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#CodedProperty",
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentSpecification"
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#DimensionProperty",
+                "http://purl.org/linked-data/cube#ComponentProperty"
             ],
-            "http://purl.org/linked-data/cube#componentProperty": [
+            "http://purl.org/linked-data/cube#codeList": [
                 {
-                    "@id": "http://purl.org/linked-data/cube#measureType"
+                    "@id": "dim2.csv#code-list"
                 }
             ],
-            "http://purl.org/linked-data/cube#dimension": [
+            "http://www.w3.org/2000/01/rdf-schema#label": [
                 {
-                    "@id": "http://purl.org/linked-data/cube#measureType"
+                    "@language": "en",
+                    "@value": "Dim2"
                 }
             ],
-            "http://purl.org/linked-data/cube#order": [
+            "http://www.w3.org/2000/01/rdf-schema#range": [
                 {
-                    "@value": 6
-                },
-                {
-                    "@value": 2
-                }
-            ]
-        },
-        {
-            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#csvcubed-build-activity",
-            "@type": [
-                "http://www.w3.org/ns/prov#Activity",
-                "http://www.w3.org/2000/01/rdf-schema#Resource"
-            ],
-            "http://www.w3.org/ns/prov#used": [
-                {
-                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0"
-                }
-            ]
-        },
-        {
-            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/dim2",
-            "@type": [
-                "http://purl.org/linked-data/cube#ComponentSet",
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentSpecification"
-            ],
-            "http://purl.org/linked-data/cube#componentProperty": [
-                {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2"
-                }
-            ],
-            "http://purl.org/linked-data/cube#dimension": [
-                {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2"
-                }
-            ],
-            "http://purl.org/linked-data/cube#order": [
-                {
-                    "@value": 5
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#class/dim2"
                 }
             ]
         },
         {
             "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#structure",
             "@type": [
-                "http://purl.org/linked-data/cube#ComponentSet",
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
                 "http://purl.org/linked-data/cube#DataStructureDefinition"
             ],
             "http://purl.org/linked-data/cube#component": [
                 {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/unit"
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/measure-type"
                 },
                 {
                     "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/another-measure"
                 },
                 {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/some-measure"
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/dim2"
                 },
                 {
                     "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/dim1"
                 },
                 {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/dim2"
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/some-measure"
                 },
                 {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/measure-type"
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/unit"
                 }
             ],
             "http://purl.org/linked-data/cube#componentProperty": [
@@ -469,19 +292,19 @@
                     "@id": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure"
                 },
                 {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure"
                 },
                 {
                     "@id": "http://purl.org/linked-data/cube#measureType"
                 },
                 {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure"
-                },
-                {
                     "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1"
                 },
                 {
-                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure"
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                },
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure"
                 }
             ],
             "http://purl.org/linked-data/cube#sliceKey": [
@@ -493,10 +316,10 @@
         {
             "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dataset",
             "@type": [
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#DataSet",
-                "http://www.w3.org/ns/dcat#Dataset",
                 "http://www.w3.org/ns/dcat#Resource",
+                "http://www.w3.org/ns/dcat#Dataset",
+                "http://purl.org/linked-data/cube#DataSet",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
                 "http://purl.org/linked-data/cube#Attachable"
             ],
             "http://purl.org/dc/terms/identifier": [
@@ -507,13 +330,13 @@
             "http://purl.org/dc/terms/issued": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:01:10.633164"
+                    "@value": "2023-03-31T17:33:01.600425"
                 }
             ],
             "http://purl.org/dc/terms/modified": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:01:10.633164"
+                    "@value": "2023-03-31T17:33:01.600425"
                 }
             ],
             "http://purl.org/dc/terms/title": [
@@ -540,17 +363,10 @@
             ]
         },
         {
-            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#class/dim1",
-            "@type": [
-                "http://www.w3.org/2000/01/rdf-schema#Class",
-                "http://www.w3.org/2000/01/rdf-schema#Resource"
-            ]
-        },
-        {
             "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#slice/cross-measures",
             "@type": [
-                "http://purl.org/linked-data/cube#ComponentSet",
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
                 "http://purl.org/linked-data/cube#SliceKey"
             ],
             "http://purl.org/linked-data/cube#componentProperty": [
@@ -559,6 +375,190 @@
                 },
                 {
                     "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/some-measure",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#measure": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 4
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#class/dim2",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/2000/01/rdf-schema#Class"
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/measure-type",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 6
+                },
+                {
+                    "@value": 2
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/dim2",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 5
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#MeasureProperty",
+                "http://purl.org/linked-data/cube#ComponentProperty"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Another Measure"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "http://www.w3.org/2001/XMLSchema#time"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/some-measure",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#MeasureProperty",
+                "http://purl.org/linked-data/cube#ComponentProperty"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Some Measure"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "http://www.w3.org/2001/XMLSchema#time"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#csvcubed-build-activity",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/prov#Activity"
+            ],
+            "http://www.w3.org/ns/prov#used": [
+                {
+                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/another-measure",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#measure": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#measure/another-measure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 7
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#class/dim1",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/2000/01/rdf-schema#Class"
+            ]
+        },
+        {
+            "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#component/dim1",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#dimension/dim1"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 1
                 }
             ]
         },
@@ -599,8 +599,8 @@
         {
             "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#unit/some-unit",
             "@type": [
-                "http://www.ontology-of-units-of-measure.org/resource/om-2/Unit",
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.ontology-of-units-of-measure.org/resource/om-2/Unit",
                 "http://qudt.org/schema/qudt/Unit"
             ],
             "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -613,8 +613,8 @@
         {
             "@id": "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv#unit/some-other-unit",
             "@type": [
-                "http://www.ontology-of-units-of-measure.org/resource/om-2/Unit",
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.ontology-of-units-of-measure.org/resource/om-2/Unit",
                 "http://qudt.org/schema/qudt/Unit"
             ],
             "http://www.w3.org/2000/01/rdf-schema#label": [

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape.csv
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape.csv
@@ -1,0 +1,2 @@
+Dim1,Obs1,Dim2,Obs2
+Value1,01:02:03,value2,True

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://purl.org/csv-cubed/qube-config/v1",
+    "title": "Testing converting a pivoted CSVW to pandas dataframe",
+    "columns": {
+        "Dim1": {
+            "type": "dimension"
+        },
+        "Obs1": {
+            "type": "observations",
+            "data_type": "time",
+            "unit": {
+                "label": "Some Unit"
+            },
+            "measure": {
+                "label": "Some Measure"
+            }
+        },
+        "Dim2": {
+            "type": "dimension"
+        },
+        "Obs2": {
+            "type": "observations",
+            "data_type": "boolean",
+            "unit": {
+                "label": "Some Other Unit"
+            },
+            "measure": {
+                "label": "Another Measure"
+            }
+        }
+    }
+}

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim1.csv
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim1.csv
@@ -1,0 +1,2 @@
+Uri Identifier,Label,Notation,Parent Uri Identifier,Sort Priority,Description
+something,Something,something,,0,

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim1.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim1.csv-metadata.json
@@ -1,0 +1,64 @@
+{
+    "@context": "http://www.w3.org/ns/csvw",
+    "@id": "dim1.csv#code-list",
+    "url": "dim1.csv",
+    "tableSchema": "dim1.table.json",
+    "rdfs:seeAlso": [
+        {
+            "@id": "dim1.csv#code-list",
+            "@type": [
+                "http://www.w3.org/ns/prov#Entity",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/dcat#Dataset",
+                "http://www.w3.org/2004/02/skos/core#ConceptScheme",
+                "http://www.w3.org/ns/dcat#Resource"
+            ],
+            "http://purl.org/dc/terms/identifier": [
+                {
+                    "@value": "Dim1"
+                }
+            ],
+            "http://purl.org/dc/terms/issued": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:00:38.318287"
+                }
+            ],
+            "http://purl.org/dc/terms/modified": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:00:38.318287"
+                }
+            ],
+            "http://purl.org/dc/terms/title": [
+                {
+                    "@language": "en",
+                    "@value": "Dim1"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Dim1"
+                }
+            ],
+            "http://www.w3.org/ns/prov#wasGeneratedBy": [
+                {
+                    "@id": "dim1.csv#csvcubed-build-activity"
+                }
+            ]
+        },
+        {
+            "@id": "dim1.csv#csvcubed-build-activity",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/prov#Activity"
+            ],
+            "http://www.w3.org/ns/prov#used": [
+                {
+                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim1.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim1.csv-metadata.json
@@ -7,11 +7,11 @@
         {
             "@id": "dim1.csv#code-list",
             "@type": [
-                "http://www.w3.org/ns/prov#Entity",
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://www.w3.org/ns/dcat#Dataset",
                 "http://www.w3.org/2004/02/skos/core#ConceptScheme",
-                "http://www.w3.org/ns/dcat#Resource"
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/dcat#Resource",
+                "http://www.w3.org/ns/prov#Entity",
+                "http://www.w3.org/ns/dcat#Dataset"
             ],
             "http://purl.org/dc/terms/identifier": [
                 {
@@ -21,13 +21,13 @@
             "http://purl.org/dc/terms/issued": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:00:38.318287"
+                    "@value": "2023-03-31T17:33:38.464981"
                 }
             ],
             "http://purl.org/dc/terms/modified": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:00:38.318287"
+                    "@value": "2023-03-31T17:33:38.464981"
                 }
             ],
             "http://purl.org/dc/terms/title": [

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim1.table.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim1.table.json
@@ -1,0 +1,58 @@
+{
+    "columns": [
+        {
+            "titles": "Uri Identifier",
+            "name": "uri_identifier",
+            "required": true,
+            "suppressOutput": true
+        },
+        {
+            "titles": "Label",
+            "name": "label",
+            "required": true,
+            "propertyUrl": "rdfs:label"
+        },
+        {
+            "titles": "Notation",
+            "name": "notation",
+            "required": true,
+            "propertyUrl": "skos:notation"
+        },
+        {
+            "titles": "Parent Uri Identifier",
+            "name": "parent_uri_identifier",
+            "required": false,
+            "propertyUrl": "skos:broader",
+            "valueUrl": "dim1.csv#{+parent_uri_identifier}"
+        },
+        {
+            "titles": "Sort Priority",
+            "name": "sort_priority",
+            "required": false,
+            "datatype": "integer",
+            "propertyUrl": "http://www.w3.org/ns/ui#sortPriority"
+        },
+        {
+            "titles": "Description",
+            "name": "description",
+            "required": false,
+            "propertyUrl": "rdfs:comment"
+        },
+        {
+            "virtual": true,
+            "name": "virt_inScheme",
+            "required": true,
+            "propertyUrl": "skos:inScheme",
+            "valueUrl": "dim1.csv#code-list"
+        },
+        {
+            "virtual": true,
+            "name": "virt_type",
+            "required": true,
+            "propertyUrl": "rdf:type",
+            "valueUrl": "skos:Concept"
+        }
+    ],
+    "aboutUrl": "dim1.csv#{+uri_identifier}",
+    "primaryKey": "uri_identifier"
+}

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim2.csv
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim2.csv
@@ -1,0 +1,2 @@
+Uri Identifier,Label,Notation,Parent Uri Identifier,Sort Priority,Description
+something-else,Something Else,something-else,,0,

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim2.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim2.csv-metadata.json
@@ -19,11 +19,11 @@
         {
             "@id": "dim2.csv#code-list",
             "@type": [
-                "http://www.w3.org/ns/prov#Entity",
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://www.w3.org/ns/dcat#Dataset",
                 "http://www.w3.org/2004/02/skos/core#ConceptScheme",
-                "http://www.w3.org/ns/dcat#Resource"
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/dcat#Resource",
+                "http://www.w3.org/ns/prov#Entity",
+                "http://www.w3.org/ns/dcat#Dataset"
             ],
             "http://purl.org/dc/terms/identifier": [
                 {
@@ -33,13 +33,13 @@
             "http://purl.org/dc/terms/issued": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:00:38.342880"
+                    "@value": "2023-03-31T17:33:38.490044"
                 }
             ],
             "http://purl.org/dc/terms/modified": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:00:38.342880"
+                    "@value": "2023-03-31T17:33:38.490044"
                 }
             ],
             "http://purl.org/dc/terms/title": [

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim2.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim2.csv-metadata.json
@@ -1,0 +1,64 @@
+{
+    "@context": "http://www.w3.org/ns/csvw",
+    "@id": "dim2.csv#code-list",
+    "url": "dim2.csv",
+    "tableSchema": "dim2.table.json",
+    "rdfs:seeAlso": [
+        {
+            "@id": "dim2.csv#csvcubed-build-activity",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/prov#Activity"
+            ],
+            "http://www.w3.org/ns/prov#used": [
+                {
+                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0"
+                }
+            ]
+        },
+        {
+            "@id": "dim2.csv#code-list",
+            "@type": [
+                "http://www.w3.org/ns/prov#Entity",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/dcat#Dataset",
+                "http://www.w3.org/2004/02/skos/core#ConceptScheme",
+                "http://www.w3.org/ns/dcat#Resource"
+            ],
+            "http://purl.org/dc/terms/identifier": [
+                {
+                    "@value": "Dim2"
+                }
+            ],
+            "http://purl.org/dc/terms/issued": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:00:38.342880"
+                }
+            ],
+            "http://purl.org/dc/terms/modified": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:00:38.342880"
+                }
+            ],
+            "http://purl.org/dc/terms/title": [
+                {
+                    "@language": "en",
+                    "@value": "Dim2"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Dim2"
+                }
+            ],
+            "http://www.w3.org/ns/prov#wasGeneratedBy": [
+                {
+                    "@id": "dim2.csv#csvcubed-build-activity"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim2.table.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim2.table.json
@@ -1,0 +1,58 @@
+{
+    "columns": [
+        {
+            "titles": "Uri Identifier",
+            "name": "uri_identifier",
+            "required": true,
+            "suppressOutput": true
+        },
+        {
+            "titles": "Label",
+            "name": "label",
+            "required": true,
+            "propertyUrl": "rdfs:label"
+        },
+        {
+            "titles": "Notation",
+            "name": "notation",
+            "required": true,
+            "propertyUrl": "skos:notation"
+        },
+        {
+            "titles": "Parent Uri Identifier",
+            "name": "parent_uri_identifier",
+            "required": false,
+            "propertyUrl": "skos:broader",
+            "valueUrl": "dim2.csv#{+parent_uri_identifier}"
+        },
+        {
+            "titles": "Sort Priority",
+            "name": "sort_priority",
+            "required": false,
+            "datatype": "integer",
+            "propertyUrl": "http://www.w3.org/ns/ui#sortPriority"
+        },
+        {
+            "titles": "Description",
+            "name": "description",
+            "required": false,
+            "propertyUrl": "rdfs:comment"
+        },
+        {
+            "virtual": true,
+            "name": "virt_inScheme",
+            "required": true,
+            "propertyUrl": "skos:inScheme",
+            "valueUrl": "dim2.csv#code-list"
+        },
+        {
+            "virtual": true,
+            "name": "virt_type",
+            "required": true,
+            "propertyUrl": "rdf:type",
+            "valueUrl": "skos:Concept"
+        }
+    ],
+    "aboutUrl": "dim2.csv#{+uri_identifier}",
+    "primaryKey": "uri_identifier"
+}

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim3.csv
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim3.csv
@@ -1,0 +1,2 @@
+Uri Identifier,Label,Notation,Parent Uri Identifier,Sort Priority,Description
+2023,2023,2023,,0,

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim3.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim3.csv-metadata.json
@@ -1,0 +1,64 @@
+{
+    "@context": "http://www.w3.org/ns/csvw",
+    "@id": "dim3.csv#code-list",
+    "url": "dim3.csv",
+    "tableSchema": "dim3.table.json",
+    "rdfs:seeAlso": [
+        {
+            "@id": "dim3.csv#code-list",
+            "@type": [
+                "http://www.w3.org/ns/prov#Entity",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/dcat#Dataset",
+                "http://www.w3.org/2004/02/skos/core#ConceptScheme",
+                "http://www.w3.org/ns/dcat#Resource"
+            ],
+            "http://purl.org/dc/terms/identifier": [
+                {
+                    "@value": "Dim3"
+                }
+            ],
+            "http://purl.org/dc/terms/issued": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:00:38.363290"
+                }
+            ],
+            "http://purl.org/dc/terms/modified": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:00:38.363290"
+                }
+            ],
+            "http://purl.org/dc/terms/title": [
+                {
+                    "@language": "en",
+                    "@value": "Dim3"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Dim3"
+                }
+            ],
+            "http://www.w3.org/ns/prov#wasGeneratedBy": [
+                {
+                    "@id": "dim3.csv#csvcubed-build-activity"
+                }
+            ]
+        },
+        {
+            "@id": "dim3.csv#csvcubed-build-activity",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/prov#Activity"
+            ],
+            "http://www.w3.org/ns/prov#used": [
+                {
+                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim3.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim3.csv-metadata.json
@@ -5,13 +5,25 @@
     "tableSchema": "dim3.table.json",
     "rdfs:seeAlso": [
         {
+            "@id": "dim3.csv#csvcubed-build-activity",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/prov#Activity"
+            ],
+            "http://www.w3.org/ns/prov#used": [
+                {
+                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0"
+                }
+            ]
+        },
+        {
             "@id": "dim3.csv#code-list",
             "@type": [
-                "http://www.w3.org/ns/prov#Entity",
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://www.w3.org/ns/dcat#Dataset",
                 "http://www.w3.org/2004/02/skos/core#ConceptScheme",
-                "http://www.w3.org/ns/dcat#Resource"
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/dcat#Resource",
+                "http://www.w3.org/ns/prov#Entity",
+                "http://www.w3.org/ns/dcat#Dataset"
             ],
             "http://purl.org/dc/terms/identifier": [
                 {
@@ -21,13 +33,13 @@
             "http://purl.org/dc/terms/issued": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:00:38.363290"
+                    "@value": "2023-03-31T17:33:38.508264"
                 }
             ],
             "http://purl.org/dc/terms/modified": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:00:38.363290"
+                    "@value": "2023-03-31T17:33:38.508264"
                 }
             ],
             "http://purl.org/dc/terms/title": [
@@ -45,18 +57,6 @@
             "http://www.w3.org/ns/prov#wasGeneratedBy": [
                 {
                     "@id": "dim3.csv#csvcubed-build-activity"
-                }
-            ]
-        },
-        {
-            "@id": "dim3.csv#csvcubed-build-activity",
-            "@type": [
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://www.w3.org/ns/prov#Activity"
-            ],
-            "http://www.w3.org/ns/prov#used": [
-                {
-                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0"
                 }
             ]
         }

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim3.table.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/dim3.table.json
@@ -1,0 +1,58 @@
+{
+    "columns": [
+        {
+            "titles": "Uri Identifier",
+            "name": "uri_identifier",
+            "required": true,
+            "suppressOutput": true
+        },
+        {
+            "titles": "Label",
+            "name": "label",
+            "required": true,
+            "propertyUrl": "rdfs:label"
+        },
+        {
+            "titles": "Notation",
+            "name": "notation",
+            "required": true,
+            "propertyUrl": "skos:notation"
+        },
+        {
+            "titles": "Parent Uri Identifier",
+            "name": "parent_uri_identifier",
+            "required": false,
+            "propertyUrl": "skos:broader",
+            "valueUrl": "dim3.csv#{+parent_uri_identifier}"
+        },
+        {
+            "titles": "Sort Priority",
+            "name": "sort_priority",
+            "required": false,
+            "datatype": "integer",
+            "propertyUrl": "http://www.w3.org/ns/ui#sortPriority"
+        },
+        {
+            "titles": "Description",
+            "name": "description",
+            "required": false,
+            "propertyUrl": "rdfs:comment"
+        },
+        {
+            "virtual": true,
+            "name": "virt_inScheme",
+            "required": true,
+            "propertyUrl": "skos:inScheme",
+            "valueUrl": "dim3.csv#code-list"
+        },
+        {
+            "virtual": true,
+            "name": "virt_type",
+            "required": true,
+            "propertyUrl": "rdf:type",
+            "valueUrl": "skos:Concept"
+        }
+    ],
+    "aboutUrl": "dim3.csv#{+uri_identifier}",
+    "primaryKey": "uri_identifier"
+}

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/standard-shape.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/standard-shape.csv-metadata.json
@@ -1,0 +1,679 @@
+{
+    "@context": "http://www.w3.org/ns/csvw",
+    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dataset",
+    "tables": [
+        {
+            "url": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv",
+            "tableSchema": {
+                "columns": [
+                    {
+                        "titles": "Dim1",
+                        "name": "dim1",
+                        "propertyUrl": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim1",
+                        "valueUrl": "dim1.csv#{+dim1}",
+                        "required": true
+                    },
+                    {
+                        "titles": "Dim2",
+                        "name": "dim2",
+                        "propertyUrl": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim2",
+                        "valueUrl": "dim2.csv#{+dim2}",
+                        "required": true
+                    },
+                    {
+                        "titles": "Dim3",
+                        "name": "dim3",
+                        "propertyUrl": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim3",
+                        "valueUrl": "dim3.csv#{+dim3}",
+                        "required": true
+                    },
+                    {
+                        "titles": "Attr Resource",
+                        "name": "attr_resource",
+                        "propertyUrl": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource",
+                        "valueUrl": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource/{+attr_resource}",
+                        "required": false
+                    },
+                    {
+                        "titles": "Attr Literal",
+                        "name": "attr_literal",
+                        "propertyUrl": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-literal",
+                        "datatype": "nonPositiveInteger",
+                        "required": false
+                    },
+                    {
+                        "titles": "Units",
+                        "name": "units",
+                        "propertyUrl": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure",
+                        "valueUrl": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#unit/{+units}",
+                        "required": true
+                    },
+                    {
+                        "titles": "Measures",
+                        "name": "measures",
+                        "propertyUrl": "http://purl.org/linked-data/cube#measureType",
+                        "valueUrl": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/{+measures}",
+                        "required": true
+                    },
+                    {
+                        "titles": "Obs",
+                        "name": "obs",
+                        "propertyUrl": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/{+measures}",
+                        "datatype": "short",
+                        "required": true
+                    },
+                    {
+                        "name": "virt_type",
+                        "virtual": true,
+                        "propertyUrl": "rdf:type",
+                        "valueUrl": "http://purl.org/linked-data/cube#Observation"
+                    },
+                    {
+                        "name": "virt_dataset",
+                        "virtual": true,
+                        "propertyUrl": "http://purl.org/linked-data/cube#dataSet",
+                        "valueUrl": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dataset"
+                    }
+                ],
+                "foreignKeys": [
+                    {
+                        "columnReference": "dim1",
+                        "reference": {
+                            "resource": "dim1.csv",
+                            "columnReference": "uri_identifier"
+                        }
+                    },
+                    {
+                        "columnReference": "dim2",
+                        "reference": {
+                            "resource": "dim2.csv",
+                            "columnReference": "uri_identifier"
+                        }
+                    },
+                    {
+                        "columnReference": "dim3",
+                        "reference": {
+                            "resource": "dim3.csv",
+                            "columnReference": "uri_identifier"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "dim1",
+                    "dim2",
+                    "dim3",
+                    "measures"
+                ],
+                "aboutUrl": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#obs/{dim1},{dim2},{dim3}@{measures}"
+            }
+        },
+        {
+            "url": "dim1.csv",
+            "tableSchema": "dim1.table.json",
+            "suppressOutput": true
+        },
+        {
+            "url": "dim2.csv",
+            "tableSchema": "dim2.table.json",
+            "suppressOutput": true
+        },
+        {
+            "url": "dim3.csv",
+            "tableSchema": "dim3.table.json",
+            "suppressOutput": true
+        }
+    ],
+    "rdfs:seeAlso": [
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#structure",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#DataStructureDefinition"
+            ],
+            "http://purl.org/linked-data/cube#component": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/an-attribute-resource"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim1"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/units"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/some-measure"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim3"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/an-attribute-literal"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim2"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/measure-type"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim3"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-literal"
+                },
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                },
+                {
+                    "@id": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim1"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/measure-type",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 8
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim2",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 2
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim2",
+            "@type": [
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#DimensionProperty",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentProperty",
+                "http://purl.org/linked-data/cube#CodedProperty"
+            ],
+            "http://purl.org/linked-data/cube#codeList": [
+                {
+                    "@id": "dim2.csv#code-list"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Dim2"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim2"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#ComponentProperty",
+                "http://purl.org/linked-data/cube#AttributeProperty"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "An attribute resource"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim1",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/2000/01/rdf-schema#Class"
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim2",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/2000/01/rdf-schema#Class"
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim3",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim3"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim3"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 3
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/some-measure",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#measure": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 7
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/an-attribute-literal",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#attribute": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-literal"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-literal"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentRequired": [
+                {
+                    "@value": false
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 5
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-literal",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#ComponentProperty",
+                "http://purl.org/linked-data/cube#AttributeProperty"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "An attribute literal"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "http://www.w3.org/2001/XMLSchema#nonPositiveInteger"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/an-attribute-resource",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#attribute": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentRequired": [
+                {
+                    "@value": false
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 4
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/units",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#attribute": [
+                {
+                    "@id": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentRequired": [
+                {
+                    "@value": true
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 6
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim1",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim1"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim1"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 1
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/some-measure",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#MeasureProperty",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#ComponentProperty"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Some Measure"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "http://www.w3.org/2001/XMLSchema#short"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim3",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/2000/01/rdf-schema#Class"
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim3",
+            "@type": [
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#DimensionProperty",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentProperty",
+                "http://purl.org/linked-data/cube#CodedProperty"
+            ],
+            "http://purl.org/linked-data/cube#codeList": [
+                {
+                    "@id": "dim3.csv#code-list"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Dim3"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim3"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dataset",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/dcat#Dataset",
+                "http://purl.org/linked-data/cube#DataSet",
+                "http://www.w3.org/ns/dcat#Resource",
+                "http://purl.org/linked-data/cube#Attachable"
+            ],
+            "http://purl.org/dc/terms/identifier": [
+                {
+                    "@value": "Testing converting a standard shape CSVW to pandas dataframe"
+                }
+            ],
+            "http://purl.org/dc/terms/issued": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:00:38.388580"
+                }
+            ],
+            "http://purl.org/dc/terms/modified": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T17:00:38.388580"
+                }
+            ],
+            "http://purl.org/dc/terms/title": [
+                {
+                    "@language": "en",
+                    "@value": "Testing converting a standard shape CSVW to pandas dataframe"
+                }
+            ],
+            "http://purl.org/linked-data/cube#structure": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#structure"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Testing converting a standard shape CSVW to pandas dataframe"
+                }
+            ],
+            "http://www.w3.org/ns/prov#wasGeneratedBy": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#csvcubed-build-activity"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#csvcubed-build-activity",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/prov#Activity"
+            ],
+            "http://www.w3.org/ns/prov#used": [
+                {
+                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim1",
+            "@type": [
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#DimensionProperty",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentProperty",
+                "http://purl.org/linked-data/cube#CodedProperty"
+            ],
+            "http://purl.org/linked-data/cube#codeList": [
+                {
+                    "@id": "dim1.csv#code-list"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Dim1"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim1"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dependency/dim1",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://rdfs.org/ns/void#Dataset"
+            ],
+            "http://rdfs.org/ns/void#dataDump": [
+                {
+                    "@id": "./dim1.csv-metadata.json"
+                }
+            ],
+            "http://rdfs.org/ns/void#uriSpace": [
+                {
+                    "@value": "dim1.csv#"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dependency/dim2",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://rdfs.org/ns/void#Dataset"
+            ],
+            "http://rdfs.org/ns/void#dataDump": [
+                {
+                    "@id": "./dim2.csv-metadata.json"
+                }
+            ],
+            "http://rdfs.org/ns/void#uriSpace": [
+                {
+                    "@value": "dim2.csv#"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dependency/dim3",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://rdfs.org/ns/void#Dataset"
+            ],
+            "http://rdfs.org/ns/void#dataDump": [
+                {
+                    "@id": "./dim3.csv-metadata.json"
+                }
+            ],
+            "http://rdfs.org/ns/void#uriSpace": [
+                {
+                    "@value": "dim3.csv#"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource/final",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Final"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#unit/some-unit",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://qudt.org/schema/qudt/Unit",
+                "http://www.ontology-of-units-of-measure.org/resource/om-2/Unit"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Some Unit"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv
@@ -1,0 +1,2 @@
+Dim1,Dim2,Dim3,Attr Resource,Attr Literal,Units,Measures,Obs
+something,something-else,2023,final,-90,some-unit,some-measure,127

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv-metadata.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape-out/testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv-metadata.json
@@ -125,117 +125,37 @@
     ],
     "rdfs:seeAlso": [
         {
-            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#structure",
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim1",
             "@type": [
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentSet",
-                "http://purl.org/linked-data/cube#DataStructureDefinition"
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#DimensionProperty",
+                "http://purl.org/linked-data/cube#ComponentProperty",
+                "http://purl.org/linked-data/cube#CodedProperty"
             ],
-            "http://purl.org/linked-data/cube#component": [
+            "http://purl.org/linked-data/cube#codeList": [
                 {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/an-attribute-resource"
-                },
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim1"
-                },
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/units"
-                },
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/some-measure"
-                },
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim3"
-                },
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/an-attribute-literal"
-                },
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim2"
-                },
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/measure-type"
+                    "@id": "dim1.csv#code-list"
                 }
             ],
-            "http://purl.org/linked-data/cube#componentProperty": [
+            "http://www.w3.org/2000/01/rdf-schema#label": [
                 {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim2"
-                },
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim3"
-                },
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/some-measure"
-                },
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-literal"
-                },
-                {
-                    "@id": "http://purl.org/linked-data/cube#measureType"
-                },
-                {
-                    "@id": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure"
-                },
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource"
-                },
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim1"
-                }
-            ]
-        },
-        {
-            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/measure-type",
-            "@type": [
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentSet",
-                "http://purl.org/linked-data/cube#ComponentSpecification"
-            ],
-            "http://purl.org/linked-data/cube#componentProperty": [
-                {
-                    "@id": "http://purl.org/linked-data/cube#measureType"
+                    "@language": "en",
+                    "@value": "Dim1"
                 }
             ],
-            "http://purl.org/linked-data/cube#dimension": [
+            "http://www.w3.org/2000/01/rdf-schema#range": [
                 {
-                    "@id": "http://purl.org/linked-data/cube#measureType"
-                }
-            ],
-            "http://purl.org/linked-data/cube#order": [
-                {
-                    "@value": 8
-                }
-            ]
-        },
-        {
-            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim2",
-            "@type": [
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentSet",
-                "http://purl.org/linked-data/cube#ComponentSpecification"
-            ],
-            "http://purl.org/linked-data/cube#componentProperty": [
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim2"
-                }
-            ],
-            "http://purl.org/linked-data/cube#dimension": [
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim2"
-                }
-            ],
-            "http://purl.org/linked-data/cube#order": [
-                {
-                    "@value": 2
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim1"
                 }
             ]
         },
         {
             "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim2",
             "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
                 "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
                 "http://purl.org/linked-data/cube#DimensionProperty",
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
                 "http://purl.org/linked-data/cube#ComponentProperty",
                 "http://purl.org/linked-data/cube#CodedProperty"
             ],
@@ -257,77 +177,21 @@
             ]
         },
         {
-            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource",
-            "@type": [
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
-                "http://purl.org/linked-data/cube#ComponentProperty",
-                "http://purl.org/linked-data/cube#AttributeProperty"
-            ],
-            "http://www.w3.org/2000/01/rdf-schema#label": [
-                {
-                    "@language": "en",
-                    "@value": "An attribute resource"
-                }
-            ]
-        },
-        {
-            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim1",
-            "@type": [
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://www.w3.org/2000/01/rdf-schema#Class"
-            ]
-        },
-        {
             "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim2",
             "@type": [
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://www.w3.org/2000/01/rdf-schema#Class"
+                "http://www.w3.org/2000/01/rdf-schema#Class",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
             ]
         },
         {
-            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim3",
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#csvcubed-build-activity",
             "@type": [
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentSet",
-                "http://purl.org/linked-data/cube#ComponentSpecification"
+                "http://www.w3.org/ns/prov#Activity"
             ],
-            "http://purl.org/linked-data/cube#componentProperty": [
+            "http://www.w3.org/ns/prov#used": [
                 {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim3"
-                }
-            ],
-            "http://purl.org/linked-data/cube#dimension": [
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim3"
-                }
-            ],
-            "http://purl.org/linked-data/cube#order": [
-                {
-                    "@value": 3
-                }
-            ]
-        },
-        {
-            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/some-measure",
-            "@type": [
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentSet",
-                "http://purl.org/linked-data/cube#ComponentSpecification"
-            ],
-            "http://purl.org/linked-data/cube#componentProperty": [
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/some-measure"
-                }
-            ],
-            "http://purl.org/linked-data/cube#measure": [
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/some-measure"
-                }
-            ],
-            "http://purl.org/linked-data/cube#order": [
-                {
-                    "@value": 7
+                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0"
                 }
             ]
         },
@@ -363,9 +227,9 @@
             "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-literal",
             "@type": [
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#AttributeProperty",
                 "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
-                "http://purl.org/linked-data/cube#ComponentProperty",
-                "http://purl.org/linked-data/cube#AttributeProperty"
+                "http://purl.org/linked-data/cube#ComponentProperty"
             ],
             "http://www.w3.org/2000/01/rdf-schema#label": [
                 {
@@ -376,34 +240,6 @@
             "http://www.w3.org/2000/01/rdf-schema#range": [
                 {
                     "@id": "http://www.w3.org/2001/XMLSchema#nonPositiveInteger"
-                }
-            ]
-        },
-        {
-            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/an-attribute-resource",
-            "@type": [
-                "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentSet",
-                "http://purl.org/linked-data/cube#ComponentSpecification"
-            ],
-            "http://purl.org/linked-data/cube#attribute": [
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource"
-                }
-            ],
-            "http://purl.org/linked-data/cube#componentProperty": [
-                {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource"
-                }
-            ],
-            "http://purl.org/linked-data/cube#componentRequired": [
-                {
-                    "@value": false
-                }
-            ],
-            "http://purl.org/linked-data/cube#order": [
-                {
-                    "@value": 4
                 }
             ]
         },
@@ -436,6 +272,89 @@
             ]
         },
         {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim3",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#DimensionProperty",
+                "http://purl.org/linked-data/cube#ComponentProperty",
+                "http://purl.org/linked-data/cube#CodedProperty"
+            ],
+            "http://purl.org/linked-data/cube#codeList": [
+                {
+                    "@id": "dim3.csv#code-list"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Dim3"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#range": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim3"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim1",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Class",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#AttributeProperty",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#ComponentProperty"
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "An attribute resource"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim3",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Class",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/an-attribute-resource",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#attribute": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource"
+                }
+            ],
+            "http://purl.org/linked-data/cube#componentRequired": [
+                {
+                    "@value": false
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 4
+                }
+            ]
+        },
+        {
             "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim1",
             "@type": [
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
@@ -459,66 +378,119 @@
             ]
         },
         {
-            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/some-measure",
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#structure",
             "@type": [
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#MeasureProperty",
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
-                "http://purl.org/linked-data/cube#ComponentProperty"
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#DataStructureDefinition"
             ],
-            "http://www.w3.org/2000/01/rdf-schema#label": [
+            "http://purl.org/linked-data/cube#component": [
                 {
-                    "@language": "en",
-                    "@value": "Some Measure"
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim3"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/measure-type"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/an-attribute-literal"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/an-attribute-resource"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim1"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/units"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim2"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/some-measure"
                 }
             ],
-            "http://www.w3.org/2000/01/rdf-schema#range": [
+            "http://purl.org/linked-data/cube#componentProperty": [
                 {
-                    "@id": "http://www.w3.org/2001/XMLSchema#short"
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim1"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-resource"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#attribute/an-attribute-literal"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim3"
+                },
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                },
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                },
+                {
+                    "@id": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure"
                 }
             ]
         },
         {
-            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim3",
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/measure-type",
             "@type": [
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://www.w3.org/2000/01/rdf-schema#Class"
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "http://purl.org/linked-data/cube#measureType"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 8
+                }
             ]
         },
         {
-            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim3",
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim3",
             "@type": [
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
-                "http://purl.org/linked-data/cube#DimensionProperty",
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentProperty",
-                "http://purl.org/linked-data/cube#CodedProperty"
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
             ],
-            "http://purl.org/linked-data/cube#codeList": [
+            "http://purl.org/linked-data/cube#componentProperty": [
                 {
-                    "@id": "dim3.csv#code-list"
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim3"
                 }
             ],
-            "http://www.w3.org/2000/01/rdf-schema#label": [
+            "http://purl.org/linked-data/cube#dimension": [
                 {
-                    "@language": "en",
-                    "@value": "Dim3"
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim3"
                 }
             ],
-            "http://www.w3.org/2000/01/rdf-schema#range": [
+            "http://purl.org/linked-data/cube#order": [
                 {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim3"
+                    "@value": 3
                 }
             ]
         },
         {
             "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dataset",
             "@type": [
+                "http://purl.org/linked-data/cube#Attachable",
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://www.w3.org/ns/dcat#Dataset",
-                "http://purl.org/linked-data/cube#DataSet",
                 "http://www.w3.org/ns/dcat#Resource",
-                "http://purl.org/linked-data/cube#Attachable"
+                "http://purl.org/linked-data/cube#DataSet",
+                "http://www.w3.org/ns/dcat#Dataset"
             ],
             "http://purl.org/dc/terms/identifier": [
                 {
@@ -528,13 +500,13 @@
             "http://purl.org/dc/terms/issued": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:00:38.388580"
+                    "@value": "2023-03-31T17:33:38.529550"
                 }
             ],
             "http://purl.org/dc/terms/modified": [
                 {
                     "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-                    "@value": "2023-03-31T17:00:38.388580"
+                    "@value": "2023-03-31T17:33:38.529550"
                 }
             ],
             "http://purl.org/dc/terms/title": [
@@ -561,40 +533,68 @@
             ]
         },
         {
-            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#csvcubed-build-activity",
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/dim2",
             "@type": [
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://www.w3.org/ns/prov#Activity"
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
             ],
-            "http://www.w3.org/ns/prov#used": [
+            "http://purl.org/linked-data/cube#componentProperty": [
                 {
-                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.1.0.dev0"
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                }
+            ],
+            "http://purl.org/linked-data/cube#dimension": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim2"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 2
                 }
             ]
         },
         {
-            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#dimension/dim1",
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/some-measure",
             "@type": [
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
-                "http://purl.org/linked-data/cube#DimensionProperty",
+                "http://purl.org/linked-data/cube#MeasureProperty",
                 "http://www.w3.org/2000/01/rdf-schema#Resource",
-                "http://purl.org/linked-data/cube#ComponentProperty",
-                "http://purl.org/linked-data/cube#CodedProperty"
-            ],
-            "http://purl.org/linked-data/cube#codeList": [
-                {
-                    "@id": "dim1.csv#code-list"
-                }
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+                "http://purl.org/linked-data/cube#ComponentProperty"
             ],
             "http://www.w3.org/2000/01/rdf-schema#label": [
                 {
                     "@language": "en",
-                    "@value": "Dim1"
+                    "@value": "Some Measure"
                 }
             ],
             "http://www.w3.org/2000/01/rdf-schema#range": [
                 {
-                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#class/dim1"
+                    "@id": "http://www.w3.org/2001/XMLSchema#short"
+                }
+            ]
+        },
+        {
+            "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#component/some-measure",
+            "@type": [
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://purl.org/linked-data/cube#ComponentSet",
+                "http://purl.org/linked-data/cube#ComponentSpecification"
+            ],
+            "http://purl.org/linked-data/cube#componentProperty": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#measure": [
+                {
+                    "@id": "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv#measure/some-measure"
+                }
+            ],
+            "http://purl.org/linked-data/cube#order": [
+                {
+                    "@value": 7
                 }
             ]
         },

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape.csv
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape.csv
@@ -1,0 +1,2 @@
+Dim1,Dim2,Dim3,Attr Resource,Attr Literal,Units,Measures,Obs
+Something,Something Else,2023,Final,-90,Some Unit,Some Measure,127

--- a/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape.json
+++ b/tests/test-cases/cli/inspect/inspector-load-dataframe/standard-shape/standard-shape.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "https://purl.org/csv-cubed/qube-config/v1",
+    "title": "Testing converting a standard shape CSVW to pandas dataframe",
+    "columns": {
+        "Dim1": {
+            "type": "dimension"
+        },
+        "Dim2": {
+            "type": "dimension"
+        },
+        "Dim3": {
+            "type": "dimension"
+        },
+        "Attr Resource": {
+            "type": "attribute",
+            "label": "An attribute resource",
+            "values": [
+                {
+                    "label": "Final"
+                }
+            ]
+        },
+        "Attr Literal": {
+            "type": "attribute",
+            "label": "An attribute literal",
+            "data_type": "nonPositiveInteger"
+        },
+        "Units": {
+            "type": "units",
+            "values": [
+                {
+                    "label": "Some Unit"
+                }
+            ]
+        },
+        "Measures": {
+            "type": "measures",
+            "values": [
+                {
+                    "label": "Some Measure"
+                }
+            ]
+        },
+        "Obs": {
+            "type": "observations",
+            "data_type": "short"
+        }
+    }
+}

--- a/tests/unit/cli/inspect/test_code_list_inspector.py
+++ b/tests/unit/cli/inspect/test_code_list_inspector.py
@@ -98,3 +98,36 @@ def test_get_table_identifiers_for_concept_scheme_error():
     assert (
         "Could not find code list table identifiers for ConceptScheme URL: 'http://gss-data.org.uk/data/gss_data/trade/ons-international-trade-in-services#scheme/itis-industry'"
     ) in str(exception.value)
+
+
+def test_get_primary_csv_url():
+    """
+    TODO:
+    """
+    path_to_cube = (
+        _test_case_base_dir
+        / "pivoted-multi-measure-dataset"
+        / "qb-id-10003.csv-metadata.json"
+    )
+    # code_list_inspector = get_code_list_inspector(path_to_cube)
+    # #    primary_catalog_metadata = (
+    # #         code_list_inspector.csvw_inspector.get_primary_catalog_metadata()
+    # #     )
+    # #     x = code_list_inspector.get_table_identifiers_for_concept_scheme(
+    # #         primary_catalog_metadata.dataset_uri
+    # #     )
+    # code_list_identifiers = code_list_inspector._code_list_table_identifiers
+    # x = code_list_identifiers
+    # csv_url = code_list_inspector.get_primary_csv_url()
+
+    code_list_inspector = get_code_list_inspector(path_to_cube)
+    # concept_scheme_url = code_list_inspector.get_table_identifiers_for_concept_scheme(
+    #    code_list_inspector.csvw_inspector.get_primary_catalog_metadata().dataset_uri
+    # )
+    x = [
+        key
+        for key in code_list_inspector.csvw_inspector._table_schema_properties.keys()
+    ]
+    csv_url = x[0]
+
+    assert csv_url == "qb-id-10003.csv"

--- a/tests/unit/cli/inspect/test_code_list_inspector.py
+++ b/tests/unit/cli/inspect/test_code_list_inspector.py
@@ -107,27 +107,7 @@ def test_get_primary_csv_url():
     path_to_cube = (
         _test_case_base_dir
         / "pivoted-multi-measure-dataset"
-        / "qb-id-10003.csv-metadata.json"
+        / "some-dimension.csv-metadata.json"
     )
-    # code_list_inspector = get_code_list_inspector(path_to_cube)
-    # #    primary_catalog_metadata = (
-    # #         code_list_inspector.csvw_inspector.get_primary_catalog_metadata()
-    # #     )
-    # #     x = code_list_inspector.get_table_identifiers_for_concept_scheme(
-    # #         primary_catalog_metadata.dataset_uri
-    # #     )
-    # code_list_identifiers = code_list_inspector._code_list_table_identifiers
-    # x = code_list_identifiers
-    # csv_url = code_list_inspector.get_primary_csv_url()
-
     code_list_inspector = get_code_list_inspector(path_to_cube)
-    # concept_scheme_url = code_list_inspector.get_table_identifiers_for_concept_scheme(
-    #    code_list_inspector.csvw_inspector.get_primary_catalog_metadata().dataset_uri
-    # )
-    x = [
-        key
-        for key in code_list_inspector.csvw_inspector._table_schema_properties.keys()
-    ]
-    csv_url = x[0]
-
-    assert csv_url == "qb-id-10003.csv"
+    assert code_list_inspector.get_primary_csv_url() == "some-dimension.csv"

--- a/tests/unit/cli/inspect/test_code_list_inspector.py
+++ b/tests/unit/cli/inspect/test_code_list_inspector.py
@@ -102,7 +102,7 @@ def test_get_table_identifiers_for_concept_scheme_error():
 
 def test_get_primary_csv_url():
     """
-    TODO:
+    Testing that the csv_url for the primary CSV defined in the code list CSV-W is correctly retrieved.
     """
     path_to_cube = (
         _test_case_base_dir

--- a/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
+++ b/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
@@ -902,3 +902,28 @@ def test_get_columns_for_component_attribute_pivoted():
     expected_titles = ["Imports Status", "Exports Status"]
 
     assert actual_titles == expected_titles
+
+
+def test_load_pandas_df_from_csv_url():
+    """
+    TODO: might even need to change test title too.
+    """
+    csvw_metadata_json_path = (
+        _test_case_base_dir
+        / "single-unit_single-measure"
+        / "energy-trends-uk-total-energy.csv-metadata.json"
+    )
+    data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
+    primary_catalog_metadata = (
+        data_cube_inspector.csvw_inspector.get_primary_catalog_metadata()
+    )
+    csv_url = data_cube_inspector.get_cube_identifiers_for_data_set(
+        primary_catalog_metadata.dataset_uri
+    ).csv_url
+
+    list_of_columns_definitions = data_cube_inspector.get_column_component_info(csv_url)
+    dataframe = data_cube_inspector.get_dataframe(
+        _test_case_base_dir / "single-unit_single-measure" / csv_url
+    )
+
+    # assert each column is the correct datatype

--- a/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
+++ b/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
@@ -910,7 +910,7 @@ def test_get_columns_for_component_attribute_pivoted():
 
 def test_get_primary_csv_url():
     """
-    TODO:
+    Testing that the csv_url for the primary CSV defined in the data cube CSV-W is correctly retrieved.
     """
     csvw_metadata_json_path = (
         _test_case_base_dir
@@ -923,26 +923,56 @@ def test_get_primary_csv_url():
     assert csv_url == "energy-trends-uk-total-energy.csv"
 
 
-def test_load_pandas_df_from_csv_url():
+def test_load_pandas_df_from_standard_shape_csv_url():
     """
-    TODO: might even need to change test title too.
+    Testing that a dataframe with columns represented in the correct data types
+    can be loaded from a standard shape CSVW and that a distinction is made between
+    attribute reasource and attribute literal columns.
     """
     csvw_metadata_json_path = (
         _test_case_base_dir
-        / "single-unit_single-measure"
-        / "energy-trends-uk-total-energy.csv-metadata.json"
+        / "inspector-load-dataframe"
+        / "standard-shape"
+        / "standard-shape-out"
+        / "standard-shape.csv-metadata.json"
     )
-
-    # csvw_metadata_json_path = _test_case_base_dir / "datacube.csv-metadata.json"
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
     csv_url = data_cube_inspector.get_primary_csv_url()
 
     dataframe, validation_errors = data_cube_inspector.get_dataframe(csv_url)
 
     assert isinstance(dataframe, pd.DataFrame)
-    assert dataframe["Period"].dtype == "string"
-    assert dataframe["Region"].dtype == "string"
-    assert dataframe["Fuel"].dtype == "string"
-    assert dataframe["Measure Type"].dtype == "string"
-    assert dataframe["Value"].dtype == "float64"
+    assert dataframe["Dim1"].dtype == "string"
+    assert dataframe["Dim2"].dtype == "string"
+    assert dataframe["Dim1"].dtype == "string"
+    assert dataframe["Attr Resource"].dtype == "string"
+    assert dataframe["Attr Literal"].dtype == "Int64"
+    assert dataframe["Units"].dtype == "string"
+    assert dataframe["Measures"].dtype == "string"
+    assert dataframe["Obs"].dtype == "short"
+    assert not any(validation_errors)
+
+
+def test_load_pandas_df_from_pivoted_shape_csv_url():
+    """
+    Testing that a dataframe with columns represented in the correct data types
+    can be loaded from a pivoted shape CSVW.
+    """
+    csvw_metadata_json_path = (
+        _test_case_base_dir
+        / "inspector-load-dataframe"
+        / "pivoted-shape"
+        / "pivoted-shape-out"
+        / "pivoted-shape.csv-metadata.json"
+    )
+    data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
+    csv_url = data_cube_inspector.get_primary_csv_url()
+
+    dataframe, validation_errors = data_cube_inspector.get_dataframe(csv_url)
+
+    assert isinstance(dataframe, pd.DataFrame)
+    assert dataframe["Dim1"].dtype == "string"
+    assert dataframe["Obs1"].dtype == "string"
+    assert dataframe["Dim2"].dtype == "string"
+    assert dataframe["Obs2"].dtype == "bool"
     assert not any(validation_errors)

--- a/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
+++ b/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
@@ -1,4 +1,8 @@
+from urllib.parse import urljoin
+
+import pandas as pd
 import pytest
+from click import Path
 
 from csvcubed.definitions import QB_MEASURE_TYPE_DIMENSION_URI, SDMX_ATTRIBUTE_UNIT_URI
 from csvcubed.models.cube.cube_shape import CubeShape
@@ -904,6 +908,21 @@ def test_get_columns_for_component_attribute_pivoted():
     assert actual_titles == expected_titles
 
 
+def test_get_primary_csv_url():
+    """
+    TODO:
+    """
+    csvw_metadata_json_path = (
+        _test_case_base_dir
+        / "single-unit_single-measure"
+        / "energy-trends-uk-total-energy.csv-metadata.json"
+    )
+    data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
+    csv_url = data_cube_inspector.get_primary_csv_url()
+
+    assert csv_url == "energy-trends-uk-total-energy.csv"
+
+
 def test_load_pandas_df_from_csv_url():
     """
     TODO: might even need to change test title too.
@@ -913,17 +932,16 @@ def test_load_pandas_df_from_csv_url():
         / "single-unit_single-measure"
         / "energy-trends-uk-total-energy.csv-metadata.json"
     )
+
+    # csvw_metadata_json_path = _test_case_base_dir / "datacube.csv-metadata.json"
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
-    primary_catalog_metadata = (
-        data_cube_inspector.csvw_inspector.get_primary_catalog_metadata()
-    )
-    csv_url = data_cube_inspector.get_cube_identifiers_for_data_set(
-        primary_catalog_metadata.dataset_uri
-    ).csv_url
+    csv_url = data_cube_inspector.get_primary_csv_url()
 
-    list_of_columns_definitions = data_cube_inspector.get_column_component_info(csv_url)
-    dataframe = data_cube_inspector.get_dataframe(
-        _test_case_base_dir / "single-unit_single-measure" / csv_url
-    )
+    dataframe = data_cube_inspector.get_dataframe(csv_url)
 
-    # assert each column is the correct datatype
+    assert isinstance(dataframe, pd.DataFrame)
+    assert dataframe["Period"].dtype == "string"
+    # assert dataframe[0]["Region"].dtype == "string"
+    # assert dataframe[0]["Fuel"].dtype == "string"
+    # assert dataframe[0]["Measure Type"].dtype == "string"
+    assert dataframe["Value"].dtype == "float64"

--- a/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
+++ b/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
@@ -934,7 +934,7 @@ def test_load_pandas_df_from_standard_shape_csv_url():
         / "inspector-load-dataframe"
         / "standard-shape"
         / "standard-shape-out"
-        / "standard-shape.csv-metadata.json"
+        / "testing-converting-a-standard-shape-csvw-to-pandas-dataframe.csv-metadata.json"
     )
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
     csv_url = data_cube_inspector.get_primary_csv_url()
@@ -963,7 +963,7 @@ def test_load_pandas_df_from_pivoted_shape_csv_url():
         / "inspector-load-dataframe"
         / "pivoted-shape"
         / "pivoted-shape-out"
-        / "pivoted-shape.csv-metadata.json"
+        / "testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv-metadata.json"
     )
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
     csv_url = data_cube_inspector.get_primary_csv_url()

--- a/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
+++ b/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
@@ -937,11 +937,12 @@ def test_load_pandas_df_from_csv_url():
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
     csv_url = data_cube_inspector.get_primary_csv_url()
 
-    dataframe = data_cube_inspector.get_dataframe(csv_url)
+    dataframe, validation_errors = data_cube_inspector.get_dataframe(csv_url)
 
     assert isinstance(dataframe, pd.DataFrame)
     assert dataframe["Period"].dtype == "string"
-    # assert dataframe[0]["Region"].dtype == "string"
-    # assert dataframe[0]["Fuel"].dtype == "string"
-    # assert dataframe[0]["Measure Type"].dtype == "string"
+    assert dataframe["Region"].dtype == "string"
+    assert dataframe["Fuel"].dtype == "string"
+    assert dataframe["Measure Type"].dtype == "string"
     assert dataframe["Value"].dtype == "float64"
+    assert not any(validation_errors)

--- a/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
+++ b/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
@@ -972,6 +972,8 @@ def test_load_pandas_df_from_pivoted_shape_csv_url():
 
     assert isinstance(dataframe, pd.DataFrame)
     assert dataframe["Dim1"].dtype == "string"
+    # Expecting data type of Obs1 column to be "string" because the data type
+    # property has been defined as "time" in the json config file.
     assert dataframe["Obs1"].dtype == "string"
     assert dataframe["Dim2"].dtype == "string"
     assert dataframe["Obs2"].dtype == "bool"

--- a/tests/unit/utils/test_uri.py
+++ b/tests/unit/utils/test_uri.py
@@ -6,6 +6,7 @@ from csvcubed.utils.uri import (
     csvw_column_name_safe,
     ensure_looks_like_uri,
     ensure_values_in_lists_looks_like_uris,
+    get_absolute_file_path,
     get_last_uri_part,
     looks_like_uri,
 )
@@ -57,11 +58,16 @@ def test_ensure_all_look_like_uri():
 
 def test_get_absolute_file_path():
     """
-    #TODO:
+    Testing the URI util function `get_absolute_file_path()` returns a normalised
+    path from a string URI which can be used to locate resources on windows as
+    well as unix/linux operating systems.
     """
-    x = "sss"
-    assert isinstance(x, type(Path))
-    assert not x.startswith(tuple[str("file:\\"), str("file:")])
+    csv_url = "file:///workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
+    absolute_csv_url = get_absolute_file_path(csv_url)
+    assert isinstance(absolute_csv_url, Path)
+    assert absolute_csv_url == Path(
+        "/workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unit/utils/test_uri.py
+++ b/tests/unit/utils/test_uri.py
@@ -7,7 +7,7 @@ from csvcubed.utils.uri import (
     csvw_column_name_safe,
     ensure_looks_like_uri,
     ensure_values_in_lists_looks_like_uris,
-    get_absolute_file_path,
+    file_uri_to_path,
     get_last_uri_part,
     looks_like_uri,
 )
@@ -63,14 +63,17 @@ def test_get_absolute_file_path():
     path from a string URI which can be used to locate resources on windows as
     well as unix/linux operating systems.
     """
-    csv_url = "file:///workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
-    absolute_csv_url = get_absolute_file_path(csv_url)
-    assert isinstance(absolute_csv_url, Path)
     if os.name == "nt":
+        windows_csv_url = "file:/C:/workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
+        absolute_csv_url = file_uri_to_path(windows_csv_url)
+        assert isinstance(absolute_csv_url, Path)
         assert absolute_csv_url == WindowsPath(
             "workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
         )
     elif os.name == "posix":
+        unix_csv_url = "file:///workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
+        absolute_csv_url = file_uri_to_path(unix_csv_url)
+        assert isinstance(absolute_csv_url, Path)
         assert absolute_csv_url == PosixPath(
             "/workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
         )

--- a/tests/unit/utils/test_uri.py
+++ b/tests/unit/utils/test_uri.py
@@ -1,3 +1,4 @@
+from os.path import exists
 from pathlib import Path
 
 import pytest
@@ -65,9 +66,8 @@ def test_get_absolute_file_path():
     csv_url = "file:///workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
     absolute_csv_url = get_absolute_file_path(csv_url)
     assert isinstance(absolute_csv_url, Path)
-    assert absolute_csv_url == Path(
-        "/workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
-    )
+    assert not exists(csv_url)
+    assert exists(absolute_csv_url)
 
 
 if __name__ == "__main__":

--- a/tests/unit/utils/test_uri.py
+++ b/tests/unit/utils/test_uri.py
@@ -67,7 +67,7 @@ def test_get_absolute_file_path():
         windows_csv_url = "C:\\Users\\someone\\Code\\something"
         absolute_csv_url = file_uri_to_path(windows_csv_url)
         assert isinstance(absolute_csv_url, Path)
-        assert absolute_csv_url == WindowsPath("Users\\someone\\Code\\something")
+        assert absolute_csv_url == WindowsPath("Users\someone\Code\something")
     elif os.name == "posix":
         unix_csv_url = "file:///workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
         absolute_csv_url = file_uri_to_path(unix_csv_url)

--- a/tests/unit/utils/test_uri.py
+++ b/tests/unit/utils/test_uri.py
@@ -1,5 +1,5 @@
-from os.path import exists
-from pathlib import Path
+import os
+from pathlib import Path, PosixPath, WindowsPath
 
 import pytest
 
@@ -66,8 +66,14 @@ def test_get_absolute_file_path():
     csv_url = "file:///workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
     absolute_csv_url = get_absolute_file_path(csv_url)
     assert isinstance(absolute_csv_url, Path)
-    assert not exists(csv_url)
-    assert exists(absolute_csv_url)
+    if os.name == "nt":
+        assert absolute_csv_url == WindowsPath(
+            "workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
+        )
+    elif os.name == "posix":
+        assert absolute_csv_url == PosixPath(
+            "/workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/utils/test_uri.py
+++ b/tests/unit/utils/test_uri.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from csvcubed.utils.uri import (
@@ -51,6 +53,15 @@ def test_ensure_all_look_like_uri():
     ensure_values_in_lists_looks_like_uris(
         ["http://some-domain.org/", "http://some-other-domain.org/"]
     )
+
+
+def test_get_absolute_file_path():
+    """
+    #TODO:
+    """
+    x = "sss"
+    assert isinstance(x, type(Path))
+    assert not x.startswith(tuple[str("file:\\"), str("file:")])
 
 
 if __name__ == "__main__":

--- a/tests/unit/utils/test_uri.py
+++ b/tests/unit/utils/test_uri.py
@@ -64,10 +64,10 @@ def test_get_absolute_file_path():
     well as unix/linux operating systems.
     """
     if os.name == "nt":
-        windows_csv_url = "C:\\Users\\someone\\Code\\something"
+        windows_csv_url = "file:\C:\\Users\\someone\\Code\\something"
         absolute_csv_url = file_uri_to_path(windows_csv_url)
         assert isinstance(absolute_csv_url, Path)
-        assert absolute_csv_url == WindowsPath("Users\someone\Code\something")
+        assert absolute_csv_url == WindowsPath("C:/Users/someone/Code/something")
     elif os.name == "posix":
         unix_csv_url = "file:///workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
         absolute_csv_url = file_uri_to_path(unix_csv_url)

--- a/tests/unit/utils/test_uri.py
+++ b/tests/unit/utils/test_uri.py
@@ -64,12 +64,10 @@ def test_get_absolute_file_path():
     well as unix/linux operating systems.
     """
     if os.name == "nt":
-        windows_csv_url = "file:/C:/workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
+        windows_csv_url = "C:\\Users\\someone\\Code\\something"
         absolute_csv_url = file_uri_to_path(windows_csv_url)
         assert isinstance(absolute_csv_url, Path)
-        assert absolute_csv_url == WindowsPath(
-            "workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
-        )
+        assert absolute_csv_url == WindowsPath("Users\\someone\\Code\\something")
     elif os.name == "posix":
         unix_csv_url = "file:///workspaces/csvcubed/tests/test-cases/cli/inspect/inspector-load-dataframe/pivoted-shape/pivoted-shape-out/testing-converting-a-pivoted-csvw-to-pandas-dataframe.csv"
         absolute_csv_url = file_uri_to_path(unix_csv_url)


### PR DESCRIPTION
PR addressing issue #747

Adds an inspect API function to load a pandas dataframe from the provided `csv_url`
The dataframe loads each column with the correct data type corresponding to the 'column_definition` for obs columns and attribute literal columns. Other columns are assigned as strings.

Two unit tests added to demonstrate this functionality (two test cases also added).

Also adds `get_primary_csv_url()` functions to both code_list_inspector and data_cube_inspector classes which retrieves the csv_url for the primary CSV defined in the CSV-W. Included two unit tests to demonstrate this function (one for each class)