### PR TITLE
#740 remove unnecessary tests sparqlquerymanager

### DIFF
--- a/src/csvcubed/cli/inspectcsvw/metadataprinter.py
+++ b/src/csvcubed/cli/inspectcsvw/metadataprinter.py
@@ -298,7 +298,35 @@ class MetadataPrinter:
 
         :return: `str` - user-friendly string which will be output to CLI.
         """
-        return f"- The {self.csvw_type_str} has the following catalog metadata:{self.result_catalog_metadata.output_str}"
+        formatted_landing_pages: str = get_printable_list_str(
+            self.result_catalog_metadata.landing_pages
+        )
+        formatted_themes: str = get_printable_list_str(
+            self.result_catalog_metadata.themes
+        )
+        formatted_keywords: str = get_printable_list_str(
+            self.result_catalog_metadata.keywords
+        )
+        formatted_description: str = self.result_catalog_metadata.description.replace(
+            linesep, f"{linesep}\t\t"
+        )
+        return f"""
+        - The {self.csvw_type_str} has the following catalog metadata:
+          - Title: {self.result_catalog_metadata.title}
+          - Label: {self.result_catalog_metadata.label}
+          - Issued: {self.result_catalog_metadata.issued}
+          - Modified: {self.result_catalog_metadata.modified}
+          - License: {self.result_catalog_metadata.license}
+          - Creator: {self.result_catalog_metadata.creator}
+          - Publisher: {self.result_catalog_metadata.publisher}
+          - Landing Pages: {formatted_landing_pages}
+          - Themes: {formatted_themes}
+          - Keywords: {formatted_keywords}
+          - Contact Point: {self.result_catalog_metadata.contact_point}
+          - Identifier: {self.result_catalog_metadata.identifier}
+          - Comment: {self.result_catalog_metadata.comment}
+          - Description: {formatted_description}
+        """
 
     @property
     def codelist_info_printable(self) -> str:

--- a/src/csvcubed/models/sparqlresults.py
+++ b/src/csvcubed/models/sparqlresults.py
@@ -5,7 +5,6 @@ SPARQL query results
 
 import logging
 from dataclasses import dataclass
-from os import linesep
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -16,7 +15,6 @@ from rdflib.query import ResultRow
 from csvcubed.definitions import QB_MEASURE_TYPE_DIMENSION_URI
 from csvcubed.models.cube.cube_shape import CubeShape
 from csvcubed.utils.iterables import first, group_by, single
-from csvcubed.utils.printable import get_printable_list_str
 from csvcubed.utils.qb.components import (
     ComponentPropertyType,
     get_component_property_as_relative_path,
@@ -34,9 +32,9 @@ class CatalogMetadataResult:
     """
 
     dataset_uri: str
-    """Data set here doesn't necessarily mean the qb:DataSet. It means eiither the qb:DataSet or the skos:ConceptScheme."""
+    """Data set here doesn't necessarily mean the qb:DataSet. It means either the qb:DataSet or the skos:ConceptScheme."""
     graph_uri: str
-    """URI representing the grapgh in which the Catalog Metadata was found."""
+    """URI representing the graph in which the Catalog Metadata was found."""
     title: str
     label: str
     issued: str
@@ -51,29 +49,6 @@ class CatalogMetadataResult:
     identifier: str
     comment: str
     description: str
-
-    @property
-    def output_str(self) -> str:
-        formatted_landing_pages: str = get_printable_list_str(self.landing_pages)
-        formatted_themes: str = get_printable_list_str(self.themes)
-        formatted_keywords: str = get_printable_list_str(self.keywords)
-        formatted_description: str = self.description.replace(linesep, f"{linesep}\t\t")
-        return f"""
-        - Title: {self.title}
-        - Label: {self.label}
-        - Issued: {self.issued}
-        - Modified: {self.modified}
-        - License: {self.license}
-        - Creator: {self.creator}
-        - Publisher: {self.publisher}
-        - Landing Pages: {formatted_landing_pages}
-        - Themes: {formatted_themes}
-        - Keywords: {formatted_keywords}
-        - Contact Point: {self.contact_point}
-        - Identifier: {self.identifier}
-        - Comment: {self.comment}
-        - Description: {formatted_description}
-        """
 
 
 @dataclass

--- a/src/csvcubed/models/sparqlresults.py
+++ b/src/csvcubed/models/sparqlresults.py
@@ -139,42 +139,12 @@ class UnitResult:
 
 
 @dataclass
-class CodelistColumnResult(DataClassBase):
-    """
-    Model to represent a codelist column.
-    """
-
-    column_property_url: Optional[str]
-    column_value_url: Optional[str]
-    column_title: Optional[str]
-    column_name: Optional[str]
-
-
-@dataclass
-class CodeListColsByDatasetUrlResult:
-    """
-    Model to represent select codelist columns by table url.
-    """
-
-    columns: List[CodelistColumnResult]
-
-
-@dataclass
 class PrimaryKeyColNameByDatasetUrlResult:
     """
     Model to represent select primary key column name by table url.
     """
 
     value: str
-
-
-@dataclass
-class PrimaryKeyColNamesByDatasetUrlResult:
-    """
-    Model to represent select primary keys by table url.
-    """
-
-    primary_key_col_names: List[PrimaryKeyColNameByDatasetUrlResult]
 
 
 @dataclass
@@ -260,7 +230,7 @@ class QubeComponentsResult:
     Model to represent select qube components sparql query result.
     """
 
-    qube_components: list[QubeComponentResult]
+    qube_components: List[QubeComponentResult]
     num_components: int
 
 
@@ -569,7 +539,7 @@ def _map_primary_key_col_name_by_csv_url_result(
 
 def map_primary_key_col_names_by_csv_url_result(
     sparql_results: List[ResultRow],
-) -> PrimaryKeyColNamesByDatasetUrlResult:
+) -> List[PrimaryKeyColNameByDatasetUrlResult]:
     """
     Maps sparql query result to `PrimaryKeyColNamesByDatasetUrlResult`
 
@@ -577,16 +547,12 @@ def map_primary_key_col_names_by_csv_url_result(
 
     :return: `PrimaryKeyColNamesByDatasetUrlResult`
     """
-    primary_key_col_names = list(
+    return list(
         map(
             lambda result: _map_primary_key_col_name_by_csv_url_result(result),
             sparql_results,
         )
     )
-    result = PrimaryKeyColNamesByDatasetUrlResult(
-        primary_key_col_names=primary_key_col_names
-    )
-    return result
 
 
 def map_metadata_dependency_results(

--- a/src/csvcubed/models/sparqlresults.py
+++ b/src/csvcubed/models/sparqlresults.py
@@ -145,14 +145,13 @@ class TableSchemaPropertiesResult:
 
 
 @dataclass
-class IsPivotedShapeMeasureResult:
+class IsPivotedShapeResult:
     """
     A dataclass that is used to return the measure of from a cube's metadata and whether that measure is part of a
     pivoted or standard shape cube.
     """
 
     csv_url: str
-    measure: str
     is_pivoted_shape: bool
 
 
@@ -564,17 +563,16 @@ def map_table_schema_properties_results(
     return [map_row(row.asdict()) for row in sparql_results]
 
 
-def map_is_pivoted_shape_for_measures_in_data_set(
+def map_is_pivoted_shape_data_set(
     sparql_results: List[ResultRow],
-) -> List[IsPivotedShapeMeasureResult]:
+) -> List[IsPivotedShapeResult]:
     """
     Maps the sparql query result to objects of type IsPivotedMeasureResult that are then returned.
     """
 
-    def map_row(row_result: Dict[str, Any]) -> IsPivotedShapeMeasureResult:
-        return IsPivotedShapeMeasureResult(
+    def map_row(row_result: Dict[str, Any]) -> IsPivotedShapeResult:
+        return IsPivotedShapeResult(
             csv_url=str(row_result["csvUrl"]),
-            measure=str(row_result["measure"]),
             is_pivoted_shape=bool(row_result["isPivotedShape"]),
         )
 

--- a/src/csvcubed/models/sparqlresults.py
+++ b/src/csvcubed/models/sparqlresults.py
@@ -147,8 +147,7 @@ class TableSchemaPropertiesResult:
 @dataclass
 class IsPivotedShapeResult:
     """
-    A dataclass that is used to return the measure of from a cube's metadata and whether that measure is part of a
-    pivoted or standard shape cube.
+    A dataclass that is used to return whether a cube is in pivoted or standard shape.
     """
 
     csv_url: str
@@ -567,7 +566,7 @@ def map_is_pivoted_shape_data_set(
     sparql_results: List[ResultRow],
 ) -> List[IsPivotedShapeResult]:
     """
-    Maps the sparql query result to objects of type IsPivotedMeasureResult that are then returned.
+    Maps the sparql query result to objects of type IsPivotedShapeResult that are then returned.
     """
 
     def map_row(row_result: Dict[str, Any]) -> IsPivotedShapeResult:

--- a/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
+++ b/src/csvcubed/utils/sparql_handler/data_cube_inspector.py
@@ -26,7 +26,7 @@ from csvcubed.models.sparqlresults import (
     CodelistsResult,
     ColumnDefinition,
     CubeTableIdentifiers,
-    IsPivotedShapeMeasureResult,
+    IsPivotedShapeResult,
     QubeComponentResult,
     QubeComponentsResult,
     UnitResult,
@@ -43,7 +43,7 @@ from csvcubed.utils.sparql_handler.sparqlquerymanager import (
     select_csvw_dsd_qube_components,
     select_data_set_dsd_and_csv_url,
     select_dsd_code_list_and_cols,
-    select_is_pivoted_shape_for_measures_in_data_set,
+    select_is_pivoted_shape_data_set,
     select_labels_for_resource_uris,
     select_units,
 )
@@ -126,7 +126,7 @@ class DataCubeInspector:
         """
 
         def _detect_shape_for_cube(
-            measures_with_shape: List[IsPivotedShapeMeasureResult],
+            csv_url_with_shape: List[IsPivotedShapeResult],
         ) -> CubeShape:
             """
             Given a metadata validator as input, returns the shape of the cube that
@@ -134,9 +134,9 @@ class DataCubeInspector:
             """
             all_pivoted = True
             all_standard_shape = True
-            for measure in measures_with_shape:
-                all_pivoted = all_pivoted and measure.is_pivoted_shape
-                all_standard_shape = all_standard_shape and not measure.is_pivoted_shape
+            for csv_url in csv_url_with_shape:
+                all_pivoted = all_pivoted and csv_url.is_pivoted_shape
+                all_standard_shape = all_standard_shape and not csv_url.is_pivoted_shape
 
             if all_pivoted:
                 return CubeShape.Pivoted
@@ -149,15 +149,15 @@ class DataCubeInspector:
                     "that are pivoted and some are not pivoted."
                 )
 
-        results = select_is_pivoted_shape_for_measures_in_data_set(
+        results = select_is_pivoted_shape_data_set(
             self.csvw_inspector.rdf_graph, list(self._cube_table_identifiers.values())
         )
 
-        map_csv_url_to_measure_shape = group_by(results, lambda r: r.csv_url)
+        map_csv_url_to_shape = group_by(results, lambda r: r.csv_url)
 
         return {
-            csv_url: _detect_shape_for_cube(measures_with_shape)
-            for (csv_url, measures_with_shape) in map_csv_url_to_measure_shape.items()
+            csv_url: _detect_shape_for_cube(csv_url_with_shape)
+            for (csv_url, csv_url_with_shape) in map_csv_url_to_shape.items()
         }
 
     @cached_property

--- a/src/csvcubed/utils/sparql_handler/sparql_queries/select_is_pivoted_shape_data_set.sparql
+++ b/src/csvcubed/utils/sparql_handler/sparql_queries/select_is_pivoted_shape_data_set.sparql
@@ -3,7 +3,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX csvw: <http://www.w3.org/ns/csvw#>
 PREFIX qb: <http://purl.org/linked-data/cube#>
 
-SELECT ?csvUrl ?measure (max(?isPivoted) as ?isPivotedShape)
+SELECT ?csvUrl (max(?isPivoted) as ?isPivotedShape)
 WHERE {
     ?dsd a qb:DataStructureDefinition;
          qb:component/qb:measure ?measure.
@@ -15,4 +15,4 @@ WHERE {
 
     BIND((STRENDS(str(?measureColumnPropertyUrl), str(?measure)) || STRENDS(str(?measure), str(?measureColumnPropertyUrl))) as ?isPivoted).
 }
-GROUP BY ?csvUrl ?measure
+GROUP BY ?csvUrl

--- a/src/csvcubed/utils/sparql_handler/sparqlquerymanager.py
+++ b/src/csvcubed/utils/sparql_handler/sparqlquerymanager.py
@@ -30,7 +30,7 @@ from csvcubed.models.sparqlresults import (
     CubeTableIdentifiers,
     IsPivotedShapeMeasureResult,
     MetadataDependenciesResult,
-    PrimaryKeyColNamesByDatasetUrlResult,
+    PrimaryKeyColNameByDatasetUrlResult,
     QubeComponentsResult,
     TableSchemaPropertiesResult,
     UnitResult,
@@ -161,7 +161,7 @@ def select_csvw_catalog_metadata(
 
     Member of :file:`./sparqlquerymanager.py`
 
-    :return: `CatalogMetadataResult`
+    :return: `List[CatalogMetadataResult]`
     """
     results: List[ResultRow] = select(
         _get_query_string_from_file(SPARQLQueryName.SELECT_CATALOG_METADATA),
@@ -176,6 +176,10 @@ def select_data_set_dsd_and_csv_url(
 ) -> List[CubeTableIdentifiers]:
     """
     Selects the dataset's DSD and CSV URL. Returns a list of cube table identifiers containing the results.
+
+    Member of :file:`./sparqlquerymanager.py`
+
+    :return: `List[CubeTableIdentifiers]`
     """
     results: List[ResultRow] = select(
         _get_query_string_from_file(SPARQLQueryName.SELECT_DATA_SET_DSD_CSV_URL),
@@ -199,9 +203,7 @@ def select_csvw_dsd_qube_components(
     map_csv_url_to_cube_shape: Dict[str, CubeShape],
 ) -> Dict[str, QubeComponentsResult]:
     """
-    Queries the list of qube components.
-
-    Returns a map of csv_url to the `QubeComponentsResult`.
+    Queries the list of qube components. Returns a map of csv_url to the `QubeComponentsResult`.
 
     Member of :file:`./sparqlquerymanager.py`
 
@@ -227,6 +229,10 @@ def select_is_pivoted_shape_for_measures_in_data_set(
 ) -> List[IsPivotedShapeMeasureResult]:
     """
     Queries the measure and whether it is a part of a pivoted or standard shape cube.
+
+    Member of :file:`./sparqlquerymanager.py`
+
+    :return: `List[IsPivotedShapeMeasureResult]`
     """
     result_is_pivoted_shape: List[ResultRow] = select(
         _get_query_string_from_file(
@@ -267,7 +273,7 @@ def select_labels_for_resource_uris(
     rdf_graph: rdflib.ConjunctiveGraph, resource_uris: List[str]
 ) -> Dict[str, str]:
     """
-    Queries a list of value uris and returns associated labels
+    Queries a list of value uris and returns associated labels.
 
     Member of :file:`./sparqlquerymanager.py`
 
@@ -291,7 +297,7 @@ def select_dsd_code_list_and_cols(
 
     Member of :file:`./sparqlquerymanager.py`
 
-    :return: `CodelistInfoSparqlResult`
+    :return: `Dict[str, CodelistsResult]`
     """
     results: List[ResultRow] = select(
         _get_query_string_from_file(SPARQLQueryName.SELECT_CODELISTS_AND_COLS),
@@ -308,7 +314,7 @@ def select_csvw_table_schema_file_dependencies(
 
     Member of :file:`./sparqlquerymanager.py`
 
-    :return: `CSVWTabelSchemasResult`
+    :return: `CSVWTableSchemaFileDependenciesResult`
     """
     results: List[ResultRow] = select(
         _get_query_string_from_file(
@@ -338,13 +344,13 @@ def select_units(rdf_graph: rdflib.ConjunctiveGraph) -> List[UnitResult]:
 
 def select_primary_key_col_names_by_csv_url(
     rdf_graph: rdflib.ConjunctiveGraph, table_url: str
-) -> PrimaryKeyColNamesByDatasetUrlResult:
+) -> List[PrimaryKeyColNameByDatasetUrlResult]:
     """
     Queries the primary keys for the given table url.
 
     Member of :file:`./sparqlquerymanager.py`
 
-    :return: `PrimaryKeyColNamesByDatasetUrlResult`
+    :return: `List[PrimaryKeyColNameByDatasetUrlResult]`
     """
     results: List[ResultRow] = select(
         _get_query_string_from_file(

--- a/src/csvcubed/utils/sparql_handler/sparqlquerymanager.py
+++ b/src/csvcubed/utils/sparql_handler/sparqlquerymanager.py
@@ -28,7 +28,7 @@ from csvcubed.models.sparqlresults import (
     ColumnDefinition,
     CSVWTableSchemaFileDependenciesResult,
     CubeTableIdentifiers,
-    IsPivotedShapeMeasureResult,
+    IsPivotedShapeResult,
     MetadataDependenciesResult,
     PrimaryKeyColNameByDatasetUrlResult,
     QubeComponentsResult,
@@ -39,7 +39,7 @@ from csvcubed.models.sparqlresults import (
     map_column_definition_results,
     map_csvw_table_schemas_file_dependencies_result,
     map_data_set_dsd_csv_url_result,
-    map_is_pivoted_shape_for_measures_in_data_set,
+    map_is_pivoted_shape_data_set,
     map_labels_for_resource_uris,
     map_metadata_dependency_results,
     map_primary_key_col_names_by_csv_url_result,
@@ -83,9 +83,7 @@ class SPARQLQueryName(Enum):
 
     SELECT_TABLE_SCHEMA_PROPERTIES = "select_table_schema_properties"
 
-    SELECT_IS_PIVOTED_SHAPE_FOR_MEASURES_IN_DATA_SET = (
-        "select_is_pivoted_shape_for_measures_in_data_set"
-    )
+    SELECT_IS_PIVOTED_SHAPE_DATA_SET = "select_is_pivoted_shape_data_set"
 
     SELECT_COLUMN_DEFINITIONS = "select_column_definitions"
 
@@ -223,10 +221,10 @@ def select_csvw_dsd_qube_components(
     )
 
 
-def select_is_pivoted_shape_for_measures_in_data_set(
+def select_is_pivoted_shape_data_set(
     rdf_graph: rdflib.ConjunctiveGraph,
     cube_table_identifiers: List[CubeTableIdentifiers],
-) -> List[IsPivotedShapeMeasureResult]:
+) -> List[IsPivotedShapeResult]:
     """
     Queries the measure and whether it is a part of a pivoted or standard shape cube.
 
@@ -235,16 +233,14 @@ def select_is_pivoted_shape_for_measures_in_data_set(
     :return: `List[IsPivotedShapeMeasureResult]`
     """
     result_is_pivoted_shape: List[ResultRow] = select(
-        _get_query_string_from_file(
-            SPARQLQueryName.SELECT_IS_PIVOTED_SHAPE_FOR_MEASURES_IN_DATA_SET
-        ),
+        _get_query_string_from_file(SPARQLQueryName.SELECT_IS_PIVOTED_SHAPE_DATA_SET),
         rdf_graph,
         values_bindings=[
             _cube_table_identifiers_to_values_binding(cube_table_identifiers)
         ],
     )
 
-    return map_is_pivoted_shape_for_measures_in_data_set(result_is_pivoted_shape)
+    return map_is_pivoted_shape_data_set(result_is_pivoted_shape)
 
 
 def _cube_table_identifiers_to_values_binding(

--- a/tests/unit/cli/inspectcsvw/test_inspectdatasetmanager.py
+++ b/tests/unit/cli/inspectcsvw/test_inspectdatasetmanager.py
@@ -774,7 +774,7 @@ def test_get_concepts_hierarchy_info_hierarchy_with_depth_of_one():
     )
     unique_identifier = get_codelist_col_title_from_col_name(
         result_code_list_cols,
-        result_primary_key_col_names_by_csv_url.primary_key_col_names[0].value,
+        result_primary_key_col_names_by_csv_url[0].value,
     )
 
     result = get_concepts_hierarchy_info(
@@ -810,7 +810,7 @@ def test_get_concepts_hierarchy_info_hierarchy_with_depth_more_than_one():
     )
     unique_identifier = get_codelist_col_title_from_col_name(
         result_code_list_cols,
-        result_primary_key_col_names_by_csv_url.primary_key_col_names[0].value,
+        result_primary_key_col_names_by_csv_url[0].value,
     )
 
     result = get_concepts_hierarchy_info(

--- a/tests/unit/cli/inspectcsvw/test_metadataprinter.py
+++ b/tests/unit/cli/inspectcsvw/test_metadataprinter.py
@@ -18,9 +18,6 @@ from tests.unit.cli.inspectcsvw.test_inspectdatasetmanager import (
     expected_dataframe_pivoted_single_measure,
 )
 from tests.unit.test_baseunit import get_test_cases_dir
-from tests.unit.utils.sparqlhandler.test_data_cube_inspector import (
-    get_arguments_qb_dataset,
-)
 
 _test_case_base_dir = get_test_cases_dir() / "cli" / "inspect"
 
@@ -151,7 +148,7 @@ def test_column_component_info_for_output():
 
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
 
-    (_, _, csv_url) = get_arguments_qb_dataset(data_cube_inspector)
+    csv_url = data_cube_inspector.get_primary_csv_url()
 
     list_of_column_component_info = data_cube_inspector.get_column_component_info(
         csv_url

--- a/tests/unit/utils/sparqlhandler/test_code_list_inspector.py
+++ b/tests/unit/utils/sparqlhandler/test_code_list_inspector.py
@@ -1,7 +1,7 @@
 import pytest
 
 from csvcubed.models.sparqlresults import CatalogMetadataResult, CodeListTableIdentifers
-from tests.helpers.inspectors_cache import get_code_list_inspector, get_csvw_rdf_manager
+from tests.helpers.inspectors_cache import get_code_list_inspector
 from tests.unit.test_baseunit import get_test_cases_dir
 
 _test_case_base_dir = get_test_cases_dir() / "cli" / "inspect"

--- a/tests/unit/utils/sparqlhandler/test_csvw_inspector.py
+++ b/tests/unit/utils/sparqlhandler/test_csvw_inspector.py
@@ -168,7 +168,6 @@ def test_get_data_cube_column_definitions_for_csv():
         / "pivoted-single-measure-dataset"
         / "qb-id-10004.csv-metadata.json"
     )
-    csvw_rdf_manager = get_csvw_rdf_manager(csvw_metadata_json_path)
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
     csv_url = data_cube_inspector.get_primary_csv_url()
 

--- a/tests/unit/utils/sparqlhandler/test_csvw_inspector.py
+++ b/tests/unit/utils/sparqlhandler/test_csvw_inspector.py
@@ -247,6 +247,10 @@ def test_get_data_cube_column_definitions_for_csv():
 
 
 def test_get_code_list_column_definitions_for_csv():
+    """
+    Tests that the code list column definitions can be successfully retrieved and
+    are as expected given the input csv.
+    """
     csvw_metadata_json_path = _test_case_base_dir / "alcohol-content.csv-metadata.json"
     csvw_inspector = get_csvw_rdf_manager(csvw_metadata_json_path).csvw_inspector
     code_list_inspector = get_code_list_inspector(csvw_metadata_json_path)

--- a/tests/unit/utils/sparqlhandler/test_csvw_inspector.py
+++ b/tests/unit/utils/sparqlhandler/test_csvw_inspector.py
@@ -7,7 +7,11 @@ from csvcubed.models.csvwtype import CSVWType
 from csvcubed.models.sparqlresults import ColumnDefinition
 from csvcubed.utils.sparql_handler.csvw_inspector import CsvWInspector
 from csvcubed.utils.sparql_handler.sparql import path_to_file_uri_for_rdflib
-from tests.helpers.inspectors_cache import get_csvw_rdf_manager, get_data_cube_inspector
+from tests.helpers.inspectors_cache import (
+    get_code_list_inspector,
+    get_csvw_rdf_manager,
+    get_data_cube_inspector,
+)
 from tests.unit.test_baseunit import get_test_cases_dir
 
 _test_case_base_dir = get_test_cases_dir() / "cli" / "inspect"
@@ -24,12 +28,10 @@ def test_get_primary_catalog_metadata():
         / "pivoted-single-measure-dataset"
         / "qb-id-10004.csv-metadata.json"
     )
-    csvw_rdf_manager = get_csvw_rdf_manager(csvw_metadata_json_path)
+    csvw_inspector = get_csvw_rdf_manager(csvw_metadata_json_path).csvw_inspector
     primary_graph_identifier = path_to_file_uri_for_rdflib(csvw_metadata_json_path)
 
-    test_catalog_metadata_result = (
-        csvw_rdf_manager.csvw_inspector.get_primary_catalog_metadata()
-    )
+    test_catalog_metadata_result = csvw_inspector.get_primary_catalog_metadata()
 
     assert test_catalog_metadata_result.graph_uri == primary_graph_identifier
 
@@ -62,9 +64,9 @@ def test_detect_csvw_type_qb_dataset():
         / "pivoted-single-measure-dataset"
         / "qb-id-10004.csv-metadata.json"
     )
-    csvw_rdf_manager = get_csvw_rdf_manager(csvw_metadata_json_path)
+    csvw_inspector = get_csvw_rdf_manager(csvw_metadata_json_path).csvw_inspector
+    csvw_type = csvw_inspector.csvw_type
 
-    csvw_type = csvw_rdf_manager.csvw_inspector.csvw_type
     assert csvw_type == CSVWType.QbDataSet
 
 
@@ -97,9 +99,9 @@ def test_detect_csvw_type_code_list():
         / "pivoted-single-measure-dataset"
         / "some-dimension.csv-metadata.json"
     )
-    csvw_rdf_manager = get_csvw_rdf_manager(csvw_metadata_json_path)
+    csvw_inspector = get_csvw_rdf_manager(csvw_metadata_json_path).csvw_inspector
+    csvw_type = csvw_inspector.csvw_type
 
-    csvw_type = csvw_rdf_manager.csvw_inspector.csvw_type
     assert csvw_type == CSVWType.CodeList
 
 
@@ -112,11 +114,7 @@ def test_get_table_info_for_csv_url():
         / "pivoted-single-measure-dataset"
         / "some-dimension.csv-metadata.json"
     )
-    csvw_rdf_manager = get_csvw_rdf_manager(csvw_metadata_json_path)
-
-    csvw_inspector: CsvWInspector = CsvWInspector(
-        csvw_rdf_manager.rdf_graph, csvw_metadata_json_path
-    )
+    csvw_inspector = get_csvw_rdf_manager(csvw_metadata_json_path).csvw_inspector
 
     result = csvw_inspector.get_table_info_for_csv_url("some-dimension.csv")
 
@@ -130,11 +128,7 @@ def test_get_table_info_multiple_tables():
     Tests retrieval of all tables from a data cube that contains multiple tables.
     """
     csvw_metadata_json_path = _test_case_base_dir / "datacube.csv-metadata.json"
-    csvw_rdf_manager = get_csvw_rdf_manager(csvw_metadata_json_path)
-
-    csvw_inspector: CsvWInspector = CsvWInspector(
-        csvw_rdf_manager.rdf_graph, csvw_metadata_json_path
-    )
+    csvw_inspector = get_csvw_rdf_manager(csvw_metadata_json_path).csvw_inspector
 
     result = csvw_inspector._table_schema_properties
 
@@ -165,7 +159,7 @@ def test_get_table_info_multiple_tables():
     assert result["alcohol-sub-type.csv"].primary_key_col_names == ["notation"]
 
 
-def test_get_column_definitions_for_csv():
+def test_get_data_cube_column_definitions_for_csv():
     """
     Ensures that the `ColumnDefinition`s with different property values can be correctly loaded from as CSV-W file.
     """
@@ -176,12 +170,7 @@ def test_get_column_definitions_for_csv():
     )
     csvw_rdf_manager = get_csvw_rdf_manager(csvw_metadata_json_path)
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
-    primary_catalog_metadata = (
-        csvw_rdf_manager.csvw_inspector.get_primary_catalog_metadata()
-    )
-    csv_url = data_cube_inspector.get_cube_identifiers_for_data_set(
-        primary_catalog_metadata.dataset_uri
-    ).csv_url
+    csv_url = data_cube_inspector.get_primary_csv_url()
 
     results = {
         c.name: c
@@ -258,6 +247,101 @@ def test_get_column_definitions_for_csv():
     )
 
 
+def test_get_code_list_column_definitions_for_csv():
+    csvw_metadata_json_path = _test_case_base_dir / "alcohol-content.csv-metadata.json"
+    csvw_inspector = get_csvw_rdf_manager(csvw_metadata_json_path).csvw_inspector
+    code_list_inspector = get_code_list_inspector(csvw_metadata_json_path)
+    csv_url = code_list_inspector.get_primary_csv_url()
+
+    results = {
+        c.name: c for c in csvw_inspector.get_column_definitions_for_csv(csv_url)
+    }
+    assert results["label"] == ColumnDefinition(
+        csv_url="alcohol-content.csv",
+        about_url=None,
+        data_type=None,
+        name="label",
+        property_url="rdfs:label",
+        required=True,
+        suppress_output=False,
+        title="Label",
+        value_url=None,
+        virtual=False,
+    )
+    assert results["notation"] == ColumnDefinition(
+        csv_url="alcohol-content.csv",
+        about_url=None,
+        data_type=None,
+        name="notation",
+        property_url="skos:notation",
+        required=True,
+        suppress_output=False,
+        title="Notation",
+        value_url=None,
+        virtual=False,
+    )
+    assert results["parent_notation"] == ColumnDefinition(
+        csv_url="alcohol-content.csv",
+        about_url=None,
+        data_type=None,
+        name="parent_notation",
+        property_url="skos:broader",
+        required=False,
+        suppress_output=False,
+        title="Parent Notation",
+        value_url="alcohol-content.csv#{+parent_notation}",
+        virtual=False,
+    )
+    assert results["sort_priority"] == ColumnDefinition(
+        csv_url="alcohol-content.csv",
+        about_url=None,
+        data_type="http://www.w3.org/2001/XMLSchema#integer",
+        name="sort_priority",
+        property_url="http://www.w3.org/ns/ui#sortPriority",
+        required=False,
+        suppress_output=False,
+        title="Sort Priority",
+        value_url=None,
+        virtual=False,
+    )
+    assert results["description"] == ColumnDefinition(
+        csv_url="alcohol-content.csv",
+        about_url=None,
+        data_type=None,
+        name="description",
+        property_url="rdfs:comment",
+        required=False,
+        suppress_output=False,
+        title="Description",
+        value_url=None,
+        virtual=False,
+    )
+    assert results["virt_inScheme"] == ColumnDefinition(
+        csv_url="alcohol-content.csv",
+        about_url=None,
+        data_type=None,
+        name="virt_inScheme",
+        property_url="skos:inScheme",
+        required=True,
+        suppress_output=False,
+        title=None,
+        value_url="alcohol-content.csv#code-list",
+        virtual=True,
+    )
+    assert results["virt_type"] == ColumnDefinition(
+        csv_url="alcohol-content.csv",
+        about_url=None,
+        data_type=None,
+        name="virt_type",
+        property_url="rdf:type",
+        required=True,
+        suppress_output=False,
+        title=None,
+        value_url="skos:Concept",
+        virtual=True,
+    )
+
+
 def test_multi_theme_and_keyword():
     """
     This test ensures that the 'select_catalog_metadata.sparql' will return the correct amount of
@@ -294,7 +378,7 @@ def test_multi_theme_and_keyword():
     }
 
 
-def test_colums_return_order():
+def test_columns_return_order():
     """This test will check if the columns are returned in the correct order."""
     csvw_metadata_json_path = (
         _test_case_base_dir

--- a/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
+++ b/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
@@ -32,6 +32,10 @@ def assert_dsd_component_equal(
     dsd_uri: str,
     required: bool,
 ):
+    """
+    Used throughout several tests to perform assertions checking that
+    data structure definition components are as expected.
+    """
     assert component.property == property
     assert component.property_type == property_type.value
     assert component.property_label == property_label

--- a/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
+++ b/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
@@ -17,9 +17,6 @@ from csvcubed.models.sparqlresults import (
 from csvcubed.utils.iterables import first
 from csvcubed.utils.qb.components import ComponentPropertyType, EndUserColumnType
 from tests.helpers.inspectors_cache import get_data_cube_inspector
-from tests.unit.cli.inspectcsvw.test_inspectdatasetmanager import (
-    get_arguments_qb_dataset,
-)
 from tests.unit.test_baseunit import get_test_cases_dir
 
 _test_case_base_dir = get_test_cases_dir() / "cli" / "inspect"
@@ -82,7 +79,6 @@ def test_exception_is_thrown_for_invalid_csv_url():
     assert "Couldn't find value for key" in str(exception.value)
 
 
-# Duplicate test
 def test_get_cube_identifiers_for_data_set_error():
     """
     Ensures we can return the correct error message when attempting to return the

--- a/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
+++ b/tests/unit/utils/sparqlhandler/test_data_cube_inspector.py
@@ -1,8 +1,7 @@
-from urllib.parse import urljoin
+from typing import List
 
 import pandas as pd
 import pytest
-from click import Path
 from pandas.testing import assert_frame_equal
 
 from csvcubed.definitions import QB_MEASURE_TYPE_DIMENSION_URI, SDMX_ATTRIBUTE_UNIT_URI
@@ -11,22 +10,58 @@ from csvcubed.models.sparqlresults import (
     CodelistResult,
     CodelistsResult,
     CubeTableIdentifiers,
+    QubeComponentResult,
     QubeComponentsResult,
     UnitResult,
 )
 from csvcubed.utils.iterables import first
 from csvcubed.utils.qb.components import ComponentPropertyType, EndUserColumnType
-from tests.helpers.inspectors_cache import get_csvw_rdf_manager, get_data_cube_inspector
+from tests.helpers.inspectors_cache import get_data_cube_inspector
 from tests.unit.cli.inspectcsvw.test_inspectdatasetmanager import (
     get_arguments_qb_dataset,
 )
 from tests.unit.test_baseunit import get_test_cases_dir
-from tests.unit.utils.sparqlhandler.test_sparqlquerymanager import (
-    assert_dsd_component_equal,
-    get_dsd_component_by_property_url,
-)
 
 _test_case_base_dir = get_test_cases_dir() / "cli" / "inspect"
+
+
+def assert_dsd_component_equal(
+    component: QubeComponentResult,
+    property: str,
+    property_type: ComponentPropertyType,
+    property_label: str,
+    csv_col_titles: List[str],
+    observation_value_column_titles: List[str],
+    dsd_uri: str,
+    required: bool,
+):
+    assert component.property == property
+    assert component.property_type == property_type.value
+    assert component.property_label == property_label
+    assert {c.title for c in component.real_columns_used_in} == set(csv_col_titles)
+    assert component.dsd_uri == dsd_uri
+    assert component.required == required
+
+    if any(observation_value_column_titles):
+        expected_obs_val_col_titles = {
+            title.strip() for title in observation_value_column_titles
+        }
+        actual_obs_val_col_titles = {
+            c.title.strip() for c in component.used_by_observed_value_columns
+        }
+        assert expected_obs_val_col_titles == actual_obs_val_col_titles
+
+
+def get_dsd_component_by_property_url(
+    components: List[QubeComponentResult], property_url: str
+) -> QubeComponentResult:
+    """
+    Filters dsd components by property url.
+    """
+    filtered_results = [
+        component for component in components if component.property == property_url
+    ]
+    return filtered_results[0]
 
 
 def test_exception_is_thrown_for_invalid_csv_url():
@@ -562,8 +597,7 @@ def test_pivoted_column_component_info():
 
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
 
-    (_, _, csv_url) = get_arguments_qb_dataset(data_cube_inspector)
-
+    csv_url = data_cube_inspector.get_primary_csv_url()
     list_of_columns_definitions = data_cube_inspector.get_column_component_info(csv_url)
 
     # get the test to check the properties and make sure the types match and the columns definitions match in the
@@ -599,7 +633,7 @@ def test_standard_column_component_info():
 
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
 
-    (_, _, csv_url) = get_arguments_qb_dataset(data_cube_inspector)
+    csv_url = data_cube_inspector.get_primary_csv_url()
 
     list_of_columns_definitions = data_cube_inspector.get_column_component_info(csv_url)
 
@@ -623,7 +657,7 @@ def test_standard_column_component_info():
 
 
 # write a test to scheck if a column is supressed will it get the new type
-def test_supressed_column_info():
+def test_suppressed_column_info():
     """
     This text checks 'get_column_component_info' returns a List of ColumnComponentInfo object in the correct order
     (that was defined in the corresponding CSV file),in this test emphasis on SUpressed columns, and contains
@@ -638,7 +672,7 @@ def test_supressed_column_info():
 
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
 
-    (_, _, csv_url) = get_arguments_qb_dataset(data_cube_inspector)
+    csv_url = data_cube_inspector.get_primary_csv_url()
 
     list_of_columns_definitions = data_cube_inspector.get_column_component_info(csv_url)
 
@@ -670,8 +704,7 @@ def test_standard_column_component_property_url():
     )
 
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
-
-    (_, _, csv_url) = get_arguments_qb_dataset(data_cube_inspector)
+    csv_url = data_cube_inspector.get_primary_csv_url()
 
     column_components = data_cube_inspector.get_dsd_qube_components_for_csv(csv_url)
 
@@ -710,7 +743,7 @@ def test_get_columns_for_component_dimension():
     )
 
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
-    (_, _, csv_url) = get_arguments_qb_dataset(data_cube_inspector)
+    csv_url = data_cube_inspector.get_primary_csv_url()
 
     delivered_columns = data_cube_inspector.get_columns_of_type(
         csv_url, EndUserColumnType.Dimension
@@ -736,7 +769,7 @@ def test_get_columns_for_component_unit():
     )
 
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
-    (_, _, csv_url) = get_arguments_qb_dataset(data_cube_inspector)
+    csv_url = data_cube_inspector.get_primary_csv_url()
 
     delivered_columns = data_cube_inspector.get_columns_of_type(
         csv_url, EndUserColumnType.Units
@@ -762,7 +795,7 @@ def test_get_columns_for_component_observation():
     )
 
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
-    (_, _, csv_url) = get_arguments_qb_dataset(data_cube_inspector)
+    csv_url = data_cube_inspector.get_primary_csv_url()
 
     delivered_columns = data_cube_inspector.get_columns_of_type(
         csv_url, EndUserColumnType.Observations
@@ -788,7 +821,7 @@ def test_get_columns_for_component_measures():
     )
 
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
-    (_, _, csv_url) = get_arguments_qb_dataset(data_cube_inspector)
+    csv_url = data_cube_inspector.get_primary_csv_url()
 
     delivered_columns = data_cube_inspector.get_columns_of_type(
         csv_url, EndUserColumnType.Measures
@@ -814,7 +847,7 @@ def test_get_columns_for_component_attribute():
     )
 
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
-    (_, _, csv_url) = get_arguments_qb_dataset(data_cube_inspector)
+    csv_url = data_cube_inspector.get_primary_csv_url()
 
     delivered_columns = data_cube_inspector.get_columns_of_type(
         csv_url, EndUserColumnType.Attribute
@@ -843,7 +876,7 @@ def test_get_columns_for_component_attribute_pivoted():
     )
 
     data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
-    (_, _, csv_url) = get_arguments_qb_dataset(data_cube_inspector)
+    csv_url = data_cube_inspector.get_primary_csv_url()
 
     delivered_columns = data_cube_inspector.get_columns_of_type(
         csv_url, EndUserColumnType.Attribute

--- a/tests/unit/utils/sparqlhandler/test_sparqlquerymanager.py
+++ b/tests/unit/utils/sparqlhandler/test_sparqlquerymanager.py
@@ -121,107 +121,6 @@ def _get_code_list_column_by_property_url(
     return filtered_results[0]
 
 
-def test_ask_is_csvw_code_list():
-    """
-    Should return true if the input rdf graph is a code list.
-    """
-    csvw_metadata_json_path = _test_case_base_dir / "codelist.csv-metadata.json"
-    csvw_rdf_manager = get_csvw_rdf_manager(csvw_metadata_json_path)
-    csvw_metadata_rdf_graph = csvw_rdf_manager.rdf_graph
-
-    is_code_list = ask_is_csvw_code_list(csvw_metadata_rdf_graph)
-
-    assert is_code_list is True
-
-
-def test_ask_is_csvw_qb_dataset():
-    """
-    Should return true if the input rdf graph is a qb dataset.
-    """
-    csvw_metadata_json_path = _test_case_base_dir / "datacube.csv-metadata.json"
-    csvw_rdf_manager = get_csvw_rdf_manager(csvw_metadata_json_path)
-    csvw_metadata_rdf_graph = csvw_rdf_manager.rdf_graph
-
-    is_qb_dataset = ask_is_csvw_qb_dataset(csvw_metadata_rdf_graph)
-
-    assert is_qb_dataset is True
-
-
-def test_get_primary_catalog_metadata_for_dataset():
-    """
-    Should return expected `CatalogMetadataResult`.
-    """
-    csvw_metadata_json_path = _test_case_base_dir / "datacube.csv-metadata.json"
-    csvw_rdf_manager = get_csvw_rdf_manager(csvw_metadata_json_path)
-
-    result: CatalogMetadataResult = (
-        csvw_rdf_manager.csvw_inspector.get_primary_catalog_metadata()
-    )
-
-    assert result.dataset_uri == "alcohol-bulletin.csv#dataset"
-    assert result.title == "Alcohol Bulletin"
-    assert result.label == "Alcohol Bulletin"
-    assert (
-        dateutil.parser.isoparse(result.issued).strftime("%Y-%m-%d %H:%M:%S%z")
-        == "2016-02-26 09:30:00+0000"
-    )
-    assert (
-        dateutil.parser.isoparse(result.modified).strftime("%Y-%m-%d %H:%M:%S%z")
-        == "2022-02-11 21:00:09+0000"
-    )
-    assert (
-        result.comment
-        == "Quarterly statistics from the 4 different alcohol duty regimes administered by HM Revenue and Customs."
-    )
-    assert (
-        result.description
-        == "The Alcohol Bulletin National Statistics present statistics from the 4\ndifferent alcohol duties administered by HM Revenue and Customs (HMRC): [Wine\nDuty](https://www.gov.uk/government/collections/wine-duty) (wine and made-\nwine), [Spirits Duty](https://www.gov.uk/guidance/spirits-duty), [Beer\nDuty](https://www.gov.uk/guidance/beer-duty) and [Cider\nDuty](https://www.gov.uk/government/collections/cider-duty).\n\nThe Alcohol Bulletin is updated quarterly and includes statistics on duty\nreceipts up to the latest full month before its release, and statistics\nrelating to clearances and production that are one month behind that of duty\nreceipts.\n\n[Archive versions of the Alcohol Bulletin published on GOV.UK after August\n2019](https://webarchive.nationalarchives.gov.uk/ukgwa/*/https://www.gov.uk/government/statistics/alcohol-\nbulletin) are no longer hosted on this page and are instead available via the\nUK Government Web Archive, from the National Archives.\n\n[Archive versions of the Alcohol Bulletin published between 2008 and August\n2019](https://www.uktradeinfo.com/trade-data/tax-and-duty-bulletins/) are\nfound on the UK Trade Info website.\n\n## Quality report\n\nFurther details for this statistical release, including data suitability and\ncoverage, are included within the [Alcohol Bulletin quality\nreport](https://www.gov.uk/government/statistics/quality-report-alcohol-\nduties-publications-bulletin-and-factsheet).\n\n  *[HMRC]: HM Revenue and Customs\n  *[UK]: United Kingdom\n\n"
-    )
-    assert result.license == "None"
-    assert (
-        result.creator
-        == "https://www.gov.uk/government/organisations/hm-revenue-customs"
-    )
-    assert (
-        result.publisher
-        == "https://www.gov.uk/government/organisations/hm-revenue-customs"
-    )
-    assert (
-        len(result.landing_pages) == 1
-        and result.landing_pages[0]
-        == "https://www.gov.uk/government/statistics/alcohol-bulletin"
-    )
-    assert (
-        len(result.themes) == 1
-        and result.themes[0] == "http://gss-data.org.uk/def/gdp#trade"
-    )
-    assert len(result.keywords) == 1 and result.keywords[0] == ""
-    assert result.contact_point == "None"
-    assert result.identifier == "Alcohol Bulletin"
-
-
-def test_select_single_unit_from_dsd():
-    """
-    Should return expected `UnitResult`.
-    """
-    csvw_metadata_json_path = (
-        _test_case_base_dir
-        / "single-unit_multi-measure"
-        / "final-uk-greenhouse-gas-emissions-national-statistics-1990-to-2020.csv-metadata.json"
-    )
-    data_cube_inspector = get_data_cube_inspector(csvw_metadata_json_path)
-
-    result: UnitResult = data_cube_inspector.get_unit_for_uri(
-        "final-uk-greenhouse-gas-emissions-national-statistics-1990-to-2020.csv#unit/mtco2e"
-    )
-
-    assert result.unit_label == "MtCO2e"
-    assert (
-        result.unit_uri
-        == "final-uk-greenhouse-gas-emissions-national-statistics-1990-to-2020.csv#unit/mtco2e"
-    )
-
-
 def test_select_table_schema_dependencies():
     """
     Test that we can successfully identify all table schema file dependencies from a CSV-W.
@@ -247,7 +146,6 @@ def test_select_table_schema_dependencies():
     }
 
 
-# Calling SPARQL query directly
 def test_select_codelist_cols_by_csv_url():
     """
     Should return expected `CodeListColsByDatasetUrlResult`.
@@ -301,7 +199,6 @@ def test_select_codelist_cols_by_csv_url():
     _assert_code_list_column_equal(column, None, "rdf:type", "skos:Concept")
 
 
-# Calling SPARQL query directly
 def test_select_metadata_dependencies():
     """
     Test that we can extract `void:DataSet` dependencies from a csvcubed CSV-W output.

--- a/tests/unit/utils/sparqlhandler/test_sparqlquerymanager.py
+++ b/tests/unit/utils/sparqlhandler/test_sparqlquerymanager.py
@@ -1,13 +1,9 @@
 from pathlib import Path
-from typing import List
 
 import pytest
 from rdflib import DCAT, RDF, RDFS, ConjunctiveGraph, Graph, Literal, URIRef
 
-from csvcubed.models.sparqlresults import (
-    IsPivotedShapeMeasureResult,
-    MetadataDependenciesResult,
-)
+from csvcubed.models.sparqlresults import MetadataDependenciesResult
 from csvcubed.utils.rdf import parse_graph_retain_relative
 from csvcubed.utils.sparql_handler.sparqlquerymanager import (
     select_csvw_table_schema_file_dependencies,
@@ -19,19 +15,6 @@ from tests.unit.test_baseunit import get_test_cases_dir
 
 _test_case_base_dir = get_test_cases_dir() / "cli" / "inspect"
 _csvw_test_cases_dir = get_test_cases_dir() / "utils" / "csvw"
-
-
-# TODO this function may have to become a cached property to ensure test coverage of the IsPivotedShapeMeasureResult class
-def _get_measure_by_measure_uri(
-    results: List[IsPivotedShapeMeasureResult], measure_uri: str
-) -> IsPivotedShapeMeasureResult:
-    """
-    Filters measures by measure uri.
-    """
-    filtered_results = [result for result in results if result.measure == measure_uri]
-    assert len(filtered_results) == 1
-
-    return filtered_results[0]
 
 
 def test_select_table_schema_dependencies():

--- a/tests/unit/utils/sparqlhandler/test_sparqlquerymanager.py
+++ b/tests/unit/utils/sparqlhandler/test_sparqlquerymanager.py
@@ -94,6 +94,7 @@ def get_dsd_component_by_property_url(
     return filtered_results[0]
 
 
+# TODO this function may have to become a cached property to ensure test coverage of the IsPivotedShapeMeasureResult class
 def _get_measure_by_measure_uri(
     results: List[IsPivotedShapeMeasureResult], measure_uri: str
 ) -> IsPivotedShapeMeasureResult:
@@ -324,79 +325,6 @@ def test_select_metadata_dependencies():
         data_dump=expected_dependency_file.absolute().as_uri(),
         uri_space="dimension.csv#",
     )
-
-
-def test_select_is_pivoted_shape_for_measures_in_pivoted_shape_data_set():
-    """
-    Checks that the measures retrieved from a metadata file that represents a pivoted shape cube are as expected.
-    """
-    csvw_metadata_json_path = (
-        _test_case_base_dir
-        / "pivoted-multi-measure-dataset"
-        / "qb-id-10003.csv-metadata.json"
-    )
-    csvw_rdf_manager = get_csvw_rdf_manager(csvw_metadata_json_path)
-    csvw_metadata_rdf_graph = csvw_rdf_manager.rdf_graph
-    results = select_is_pivoted_shape_for_measures_in_data_set(
-        csvw_metadata_rdf_graph,
-        [
-            CubeTableIdentifiers(
-                "qb-id-10003.csv",
-                "qb-id-10003.csv#dataset",
-                "qb-id-10003.csv#structure",
-            )
-        ],
-    )
-
-    assert results is not None
-    assert len(results) == 2
-
-    result = _get_measure_by_measure_uri(
-        results, "qb-id-10003.csv#measure/some-measure"
-    )
-    assert result.measure == "qb-id-10003.csv#measure/some-measure"
-    assert result.is_pivoted_shape == True
-
-    result = _get_measure_by_measure_uri(
-        results, "qb-id-10003.csv#measure/some-other-measure"
-    )
-    assert result.measure == "qb-id-10003.csv#measure/some-other-measure"
-    assert result.is_pivoted_shape == True
-
-
-# Calling SPARQL query directly
-def test_select_is_pivoted_shape_for_measures_in_standard_shape_data_set():
-    """
-    Checks that the measures retrieved from a metadata file that represents a standard shape cube are as expected.
-    """
-    csvw_metadata_json_path = (
-        _test_case_base_dir
-        / "single-unit_single-measure"
-        / "energy-trends-uk-total-energy.csv-metadata.json"
-    )
-    csvw_rdf_manager = get_csvw_rdf_manager(csvw_metadata_json_path)
-    csvw_metadata_rdf_graph = csvw_rdf_manager.rdf_graph
-    results = select_is_pivoted_shape_for_measures_in_data_set(
-        csvw_metadata_rdf_graph,
-        [
-            CubeTableIdentifiers(
-                "energy-trends-uk-total-energy.csv",
-                "energy-trends-uk-total-energy.csv#dataset",
-                "energy-trends-uk-total-energy.csv#structure",
-            )
-        ],
-    )
-
-    assert results is not None
-    assert len(results) == 1
-
-    result = _get_measure_by_measure_uri(
-        results, "energy-trends-uk-total-energy.csv#measure/energy-consumption"
-    )
-    assert (
-        result.measure == "energy-trends-uk-total-energy.csv#measure/energy-consumption"
-    )
-    assert result.is_pivoted_shape == False
 
 
 def test_rdf_dependency_loaded() -> None:


### PR DESCRIPTION
- Redundant tests removed from `test_sparqlquerymanager.py`
- Redundant SPARQL results classes removed from `sparqlresults.py`
- `output_str` property removed from `CatalogMetadata` class and moved to `MetadataPrinter`
- Cached inspector helpers replacing direct instantiation of `Inspector` classes in test files
- `IsPivotedShapeMeasureResult` renamed to `IsPivotedShapeResult` and associated functions updated