### PR TITLE
822 context bug

### DIFF
--- a/src/csvcubed/writers/skoscodelistwriter.py
+++ b/src/csvcubed/writers/skoscodelistwriter.py
@@ -175,6 +175,7 @@ class SkosCodeListWriter(WriterBase):
             }
         )
         return {
+            "@context": "http://www.w3.org/ns/csvw",
             "columns": csvw_columns,
             "aboutUrl": self.uri_helper.get_concept_uri("{+uri_identifier}"),
             "primaryKey": "uri_identifier",

--- a/tests/behaviour/skoscodelists.feature
+++ b/tests/behaviour/skoscodelists.feature
@@ -1,6 +1,5 @@
 Feature: Test outputting CSV-Ws containing `SKOS:ConceptScheme`s.
 
-  @wip
   Scenario: A basic code list can be serialised to a valid CSV-W described in SKOS containing csvcubed version specific rdf.
     Given a NewQbCodeList named "Basic Code-list"
     When the code list is serialised to CSV-W

--- a/tests/behaviour/skoscodelists.feature
+++ b/tests/behaviour/skoscodelists.feature
@@ -1,11 +1,16 @@
 Feature: Test outputting CSV-Ws containing `SKOS:ConceptScheme`s.
 
+  @wip
   Scenario: A basic code list can be serialised to a valid CSV-W described in SKOS containing csvcubed version specific rdf.
     Given a NewQbCodeList named "Basic Code-list"
     When the code list is serialised to CSV-W
     Then the file at "basic-code-list.csv" should exist
     And the file at "basic-code-list.csv-metadata.json" should exist
     And the file at "basic-code-list.table.json" should exist
+    And the file at "basic-code-list.table.json" should contain the line
+    """
+    "@context": "http://www.w3.org/ns/csvw"
+    """
     And csvlint validation of "basic-code-list.csv-metadata.json" should succeed
     And csv2rdf on "basic-code-list.csv-metadata.json" should succeed
     And the RDF should pass "skos" SPARQL tests
@@ -54,7 +59,7 @@ Feature: Test outputting CSV-Ws containing `SKOS:ConceptScheme`s.
     """
       @prefix basicCodeList: <{{rdf_input_directory}}/basic-code-list.csv#>.
       @prefix prov: <http://www.w3.org/ns/prov#> .
-        
+
       basicCodeList:csvcubed-build-activity a prov:Activity;
                                             prov:used <{{csvcubed_version_identifier}}>.
     """

--- a/tests/behaviour/steps/skoscodelists.py
+++ b/tests/behaviour/steps/skoscodelists.py
@@ -1,5 +1,6 @@
 import shutil
 from pathlib import Path
+from textwrap import dedent
 
 from behave import Given, When, then
 from csvcubeddevtools.behaviour.file import get_context_temp_dir_path
@@ -123,3 +124,14 @@ def step_imp(context, config_file: Path):
         fail_when_validation_error_occurs=True,
         validation_errors_file_name=None,
     )
+
+
+@then('the file at "{file}" should contain the line')
+def step_impl(context, file):
+    temp_dir = get_context_temp_dir_path(context)
+    with open(temp_dir / file, "r") as f:
+        file_contents = dedent(f.read()).strip().splitlines(keepends=True)
+    expected_contents = dedent(context.text).strip().splitlines(keepends=True)
+    isitthere = [ex for ex in file_contents if ex == expected_contents[0]]
+    assert any(isitthere)
+    # assert not set(expected_contents).isdisjoint(set(file_contents))

--- a/tests/behaviour/steps/skoscodelists.py
+++ b/tests/behaviour/steps/skoscodelists.py
@@ -132,6 +132,5 @@ def step_impl(context, file):
     with open(temp_dir / file, "r") as f:
         file_contents = dedent(f.read()).strip().splitlines(keepends=True)
     expected_contents = dedent(context.text).strip().splitlines(keepends=True)
-    isitthere = [ex for ex in file_contents if ex == expected_contents[0]]
+    isitthere = [ex for ex in file_contents if expected_contents[0] in ex]
     assert any(isitthere)
-    # assert not set(expected_contents).isdisjoint(set(file_contents))

--- a/tests/behaviour/steps/skoscodelists.py
+++ b/tests/behaviour/steps/skoscodelists.py
@@ -126,11 +126,16 @@ def step_imp(context, config_file: Path):
     )
 
 
+# Adding a step to demonstrate that the table.json files will now begin with
+# "@context": "http://www.w3.org/ns/csvw" which makes the csvw pass the
+# csvw-check tool (addresses: https://app.zenhub.com/workspaces/features-squad-61b72275ac896c0010a1b00b/issues/gh/gss-cogs/csvcubed/822).
+#
+# This step should be removed after completing the ticket which integrates
+# csvw-check into our behaviour tests by replacing the csvlint steps.
 @then('the file at "{file}" should contain the line')
 def step_impl(context, file):
     temp_dir = get_context_temp_dir_path(context)
     with open(temp_dir / file, "r") as f:
         file_contents = dedent(f.read()).strip().splitlines(keepends=True)
     expected_contents = dedent(context.text).strip().splitlines(keepends=True)
-    isitthere = [ex for ex in file_contents if expected_contents[0] in ex]
-    assert any(isitthere)
+    assert any([ex for ex in file_contents if expected_contents[0] in ex])


### PR DESCRIPTION
Addresses bug ticket #822

csvw-check was finding an error in our cube outputs when they have a locally defined code list.
`tables.1.tableSchema: A @context node must be defined.`

To solve this issue, we have added an extra line when writing in `skoscodelistwriter.py` and specifically to the `table.json` files so that they begin with a @context node.

This change results in a `Valid CSV-W` message after running csvw-check. However, we wanted to include a test which would demonstrate this change but we are unable to use csvw-check in our behave tests until ticket #824 has been completed. Until then, we have added an extra step to one behave test which verifies that the `skoscodelistwriter` has included the node in the correct place. I have added a comment in the code to explain that this should be deleted when the followup ticket has been completed.