### PR TITLE
[BUG] Cannot use 'Value' as the column name for observation column

### DIFF
--- a/src/csvcubed/utils/csvdataset.py
+++ b/src/csvcubed/utils/csvdataset.py
@@ -307,12 +307,13 @@ def _melt_data_set(
     id_cols = list(set(data_set.columns) - set(value_cols))
 
     # Checking for any columns with the title "Value" and changing the value_name
-    # parameter passed to the melt function to "Not-Value" so that we don't
+    # parameter passed to the melt function to a random string so that we don't
     # trigger a pandas ValueError.
     value_name = "Value"
     for col_title in value_cols:
         if col_title == "Value":
-            value_name = "Not-Value"
+            rand_value_name = str(uuid1())
+            value_name = rand_value_name
 
     # Melting the data set using pandas melt function.
     melted_df = pd.melt(
@@ -324,8 +325,8 @@ def _melt_data_set(
     )
 
     # Renaming columns in the returned melted df to their original title "Value"
-    if value_name == "Not-Value":
-        melted_df.rename(columns={"Not-Value": "Value"}, inplace=True)
+    if value_name == rand_value_name:
+        melted_df.rename(columns={rand_value_name: "Value"}, inplace=True)
 
     return melted_df
 

--- a/src/csvcubed/utils/csvdataset.py
+++ b/src/csvcubed/utils/csvdataset.py
@@ -310,8 +310,9 @@ def _melt_data_set(
     # parameter passed to the melt function to "Not-Value" so that we don't
     # trigger a pandas ValueError.
     value_name = "Value"
-    if "Value" in value_cols:
-        value_name = "Not-Value"
+    for col_title in value_cols:
+        if col_title == "Value":
+            value_name = "Not-Value"
 
     # Melting the data set using pandas melt function.
     melted_df = pd.melt(

--- a/src/csvcubed/utils/csvdataset.py
+++ b/src/csvcubed/utils/csvdataset.py
@@ -310,9 +310,9 @@ def _melt_data_set(
     # parameter passed to the melt function to a random string so that we don't
     # trigger a pandas ValueError.
     value_name = "Value"
+    rand_value_name = f"Value_{str(uuid1())}"
     for col_title in value_cols:
         if col_title == "Value":
-            rand_value_name = str(uuid1())
             value_name = rand_value_name
 
     # Melting the data set using pandas melt function.

--- a/src/csvcubed/utils/csvdataset.py
+++ b/src/csvcubed/utils/csvdataset.py
@@ -306,14 +306,27 @@ def _melt_data_set(
     ]
     id_cols = list(set(data_set.columns) - set(value_cols))
 
+    # Checking for any columns with the title "Value" and changing the value_name
+    # parameter passed to the melt function to "Not-Value" so that we don't
+    # trigger a pandas ValueError.
+    value_name = "Value"
+    if "Value" in value_cols:
+        value_name = "Not-Value"
+
     # Melting the data set using pandas melt function.
-    return pd.melt(
+    melted_df = pd.melt(
         data_set,
         id_vars=id_cols,
         value_vars=value_cols,
-        value_name="Value",
+        value_name=value_name,
         var_name="Observation Value",
     )
+
+    # Renaming columns in the returned melted df to their original title "Value"
+    if value_name == "Not-Value":
+        melted_df.rename(columns={"Not-Value": "Value"}, inplace=True)
+
+    return melted_df
 
 
 def _get_unit_measure_col_for_standard_shape_cube(

--- a/tests/unit/inspect/test_inspectdatasetmanager.py
+++ b/tests/unit/inspect/test_inspectdatasetmanager.py
@@ -599,17 +599,7 @@ def test_get_val_counts_info_multi_unit_single_measure_dataset():
         / "new"
         / "multi-unit-single-measure-dataset.csv-metadata.json"
     )
-    # csvw_metadata_json_path = (
-    #     _test_case_base_dir
-    #     / "multi-unit_single-measure"
-    #     / "final-uk-greenhouse-gas-emissions-national-statistics-1990-to-2019.csv-metadata.json"
-    # )
-    # csvw_metadata_json_path = (
-    #     _test_case_base_dir
-    #     / "multi-unit_single-measure"
-    #     / "out"
-    #     / "cardiovascular-mortality-considered-preventable-in-persons-aged-under-75.csv-metadata.json"
-    # )
+
     data_cube_repository = get_data_cube_repository(csvw_metadata_json_path)
 
     (dataset, qube_components, csv_url) = get_arguments_qb_dataset(data_cube_repository)


### PR DESCRIPTION
Addresses #856 in which when a column is titled `Value`and we need to use the pandas `melt()` function such as when calling `transform_dataset_to_canonical_shape()` which causes an error because pandas does not allow a melted dataframe to have a column named `Value`. 

This ticket adds a rather hacky workaround in which we catch any columns called `Value` and give the melt function a `value_name` of `Not-Value` (which is then used in the melted df). We then rename the `Not-Value` column from the melted df and pass this back.

Added a unit test to verify this functionality. Compares column names from the original dataframe are a subset of the ones in the melted df.