### PR TITLE
Updated link to developer documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ csvcubed has extensive user documentation which tracks the release of csvcubed w
 
 ## Developer Documentation
 
-More detailed developer documentation for this project can be found [here](./docs/developer.md).
+More detailed developer documentation for this project can be found [here](https://github.com/GSS-Cogs/csvcubed/blob/main/docs/developer.md).
 
 ## How to report bugs
 


### PR DESCRIPTION
The link to the developer documentation was a relative URL (./docs/developer.md) in README.md which was being automatically expanded to https://pypi.org/project/csvcubed/docs/developer.md upon publishing to PyPI. This has been replaced with the absolute URL in README.md which should fix the issue.

All other links appear to be absolute so should be fine.